### PR TITLE
Add nuspec file to get dll in tools folder

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -87,7 +87,9 @@ class Build : NukeBuild
                 .SetOutputDirectory(ArtifactsDirectory)
                 .EnableNoBuild()
                 .DisableIncludeSymbols()
-                .SetVerbosity(DotNetVerbosity.Normal));
+                .SetVerbosity(DotNetVerbosity.Normal)
+                .SetProperty("NuspecFile", "../../build/Octopus.Server.Extensibility.Authentication.Ldap.nuspec")
+                .SetProperty("NuspecProperties", $"Version={OctoVersionInfo.NuGetVersion}"));
         });
 
     Target CopyToLocalPackages => _ => _

--- a/build/Octopus.Server.Extensibility.Authentication.Ldap.nuspec
+++ b/build/Octopus.Server.Extensibility.Authentication.Ldap.nuspec
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd" xmlns:octopus="http://octopus.org">
+  <metadata>
+    <id>Octopus.Server.Extensibility.Authentication.Ldap</id>
+    <title>Octopus Server Extensibility Authentication - Ldap</title>
+    <version>$version$</version>
+    <authors>Octopus Deploy</authors>
+    <owners>Octopus Deploy</owners>
+    <summary>Octopus Deploy Ldap authentication provider.</summary>
+    <description>
+      Implements the Ldap authentication provider.
+    </description>
+    <releaseNotes></releaseNotes>
+    <language>en-US</language>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/OctopusDeploy/LdapAuthenticationProvider/blob/master/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/OctopusDeploy/LdapAuthenticationProvider</projectUrl>
+    <iconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</iconUrl>
+    <tags>automation deployment</tags>
+    <developmentDependency>true</developmentDependency>
+    <dependencies>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="Novell.Directory.Ldap.NETStandard" version="3.6.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\source\Server\bin\Release\netstandard2.1\*.dll" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
The extension dll needs to be packaged in the `tools` folder to be extracted correctly by Octopus server.