### PR TITLE
Basic support for LDAP referrals

### DIFF
--- a/source/Server/Configuration/ILdapConfigurationStore.cs
+++ b/source/Server/Configuration/ILdapConfigurationStore.cs
@@ -71,5 +71,6 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         string GetGroupNameAttribute();
 
         void SetGroupNameAttribute(string groupNameAttribute);
+        bool GetReferralFollowingEnabled();
     }
 }

--- a/source/Server/Configuration/ILdapConfigurationStore.cs
+++ b/source/Server/Configuration/ILdapConfigurationStore.cs
@@ -71,6 +71,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         string GetGroupNameAttribute();
 
         void SetGroupNameAttribute(string groupNameAttribute);
+        
         bool GetReferralFollowingEnabled();
+        void SetReferralFollowingEnabled(bool enabled);
+        int GetReferralHopLimit();
+        void SetReferralHopLimit(int hopLimit);
+        int GetConstraintTimeLimit();
+        void SetConstraintTimeLimit(int timeLimit);
     }
 }

--- a/source/Server/Configuration/ILdapConfigurationStore.cs
+++ b/source/Server/Configuration/ILdapConfigurationStore.cs
@@ -6,76 +6,62 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
     public interface ILdapConfigurationStore : IExtensionConfigurationStore<LdapConfiguration>
     {
         string GetServer();
-
         void SetServer(string server);
 
         int GetPort();
-
         void SetPort(int port);
 
         void SetUseSsl(bool useSsl);
-
         bool GetUseSsl();
 
         void SetIgnoreSslErrors(bool ignoreSslErrors);
-
         bool GetIgnoreSslErrors();
 
         string GetConnectUsername();
-
         void SetConnectUsername(string username);
 
         SensitiveString GetConnectPassword();
-
         void SetConnectPassword(SensitiveString password);
 
         string GetBaseDn();
-
         void SetBaseDn(string baseDn);
 
         string GetDefaultDomain();
-
         void SetDefaultDomain(string defaultDomain);
 
         string GetUserNameAttribute();
-
         void SetUserNameAttribute(string userNameAttribute);
 
         string GetUserFilter();
-
         void SetUserFilter(string userFilter);
 
         string GetGroupFilter();
-
         void SetGroupFilter(string groupFilter);
 
         bool GetAllowAutoUserCreation();
         void SetAllowAutoUserCreation(bool allowAutoUserCreation);
 
         string GetUserDisplayNameAttribute();
-
         void SetUserDisplayNameAttribute(string userDisplayNameAttribute);
 
         string GetUserPrincipalNameAttribute();
-
         void SetUserPrincipalNameAttribute(string userPrincipalNameAttribute);
 
         string GetUserMembershipAttribute();
-
         void SetUserMembershipAttribute(string userMembershipAttribute);
 
         string GetUserEmailAttribute();
-
         void SetUserEmailAttribute(string userEmailAttribute);
 
         string GetGroupNameAttribute();
-
         void SetGroupNameAttribute(string groupNameAttribute);
         
         bool GetReferralFollowingEnabled();
         void SetReferralFollowingEnabled(bool enabled);
+
         int GetReferralHopLimit();
         void SetReferralHopLimit(int hopLimit);
+
         int GetConstraintTimeLimit();
         void SetConstraintTimeLimit(int timeLimit);
     }

--- a/source/Server/Configuration/LdapConfiguration.cs
+++ b/source/Server/Configuration/LdapConfiguration.cs
@@ -35,6 +35,16 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public bool ReferralFollowingEnabled { get; set; } = true;
 
         public LdapMappingConfiguration AttributeMapping { get; set; } = new LdapMappingConfiguration();
+        /// <summary>
+        /// Defaults to 10, as specified in the Novell LDAP library.
+        /// If set to 0, no limit is imposed.
+        /// </summary>
+        public int ReferralHopLimit { get; set; } = 10;
+
+        /// <summary>
+        /// In ms.  Defaults to 0.
+        /// </summary>
+        public int ConstraintTimeLimit { get; set; } = 0;
     }
 
     public class LdapMappingConfiguration

--- a/source/Server/Configuration/LdapConfiguration.cs
+++ b/source/Server/Configuration/LdapConfiguration.cs
@@ -44,7 +44,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         /// In ms.  Defaults to 0 (i.e. no limit)
         /// </summary>
         public int ConstraintTimeLimit { get; set; } = 0;
-        
+
         public LdapMappingConfiguration AttributeMapping { get; set; } = new LdapMappingConfiguration();
     }
 

--- a/source/Server/Configuration/LdapConfiguration.cs
+++ b/source/Server/Configuration/LdapConfiguration.cs
@@ -34,7 +34,6 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 
         public bool ReferralFollowingEnabled { get; set; } = true;
 
-        public LdapMappingConfiguration AttributeMapping { get; set; } = new LdapMappingConfiguration();
         /// <summary>
         /// Defaults to 10, as specified in the Novell LDAP library.
         /// If set to 0, no limit is imposed.
@@ -45,6 +44,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         /// In ms.  Defaults to 0 (i.e. no limit)
         /// </summary>
         public int ConstraintTimeLimit { get; set; } = 0;
+        
+        public LdapMappingConfiguration AttributeMapping { get; set; } = new LdapMappingConfiguration();
     }
 
     public class LdapMappingConfiguration

--- a/source/Server/Configuration/LdapConfiguration.cs
+++ b/source/Server/Configuration/LdapConfiguration.cs
@@ -42,7 +42,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public int ReferralHopLimit { get; set; } = 10;
 
         /// <summary>
-        /// In ms.  Defaults to 0.
+        /// In ms.  Defaults to 0 (i.e. no limit)
         /// </summary>
         public int ConstraintTimeLimit { get; set; } = 0;
     }

--- a/source/Server/Configuration/LdapConfiguration.cs
+++ b/source/Server/Configuration/LdapConfiguration.cs
@@ -32,6 +32,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 
         public bool AllowAutoUserCreation { get; set; }
 
+        public bool ReferralFollowingEnabled { get; set; } = true;
+
         public LdapMappingConfiguration AttributeMapping { get; set; } = new LdapMappingConfiguration();
     }
 

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -20,7 +20,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public const string AllowAutoUserCreationDescription = "Whether unknown users will be automatically created upon successful login.";
         public const string ReferralFollowingEnabledDescription = "Sets whether to allow referral following.";
         public const string ReferralHopLimitDescription = "Sets the maximum number of referrals to follow during automatic referral following.";
-        public const string ConstraintTimeLimitDescription = "Sets the time limit in ms for LDAP operations on the directory.";
+        public const string ConstraintTimeLimitDescription = "Sets the time limit in ms for LDAP operations on the directory.  0 specifies no limit.";
 
         [DisplayName("Server")]
         [Description(ServerDescription)]

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -18,6 +18,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public const string UserFilterDescription = "The filter to use when searching valid users.";
         public const string GroupFilterDescription = "The filter to use when searching valid user groups.";
         public const string AllowAutoUserCreationDescription = "Whether unknown users will be automatically created upon successful login.";
+        public const string ReferralFollowingEnabledDescription = "Sets whether to enable referral following.";
 
 
         [DisplayName("Server")]
@@ -74,6 +75,11 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         [Description(AllowAutoUserCreationDescription)]
         [Writeable]
         public bool AllowAutoUserCreation { get; set; }
+
+        [DisplayName("ReferralFollowingEnabledDescription")]
+        [Description(ReferralFollowingEnabledDescription)]
+        [Writeable]
+        public bool ReferralFollowingEnabled { get; set; }
 
         [DisplayName("Attribute Mapping")]
         public LdapMappingConfigurationResource AttributeMapping { get; set; } = new LdapMappingConfigurationResource();

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -77,21 +77,6 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         [Writeable]
         public bool AllowAutoUserCreation { get; set; }
 
-        [DisplayName("Referral Following Enabled")]
-        [Description(ReferralFollowingEnabledDescription)]
-        [Writeable]
-        public bool ReferralFollowingEnabled { get; set; }
-
-        [DisplayName("Referral Hop Limit")]
-        [Description(ReferralHopLimitDescription)]
-        [Writeable]
-        public static string ReferralHopLimit { get; set; }
-
-        [DisplayName("Constraint Time Limit")]
-        [Description(ConstraintTimeLimitDescription)]
-        [Writeable]
-        public static string ConstraintTimeLimit { get; set; }
-
         [DisplayName("Attribute Mapping")]
         public LdapMappingConfigurationResource AttributeMapping { get; set; } = new LdapMappingConfigurationResource();
     }

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -18,8 +18,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public const string UserFilterDescription = "The filter to use when searching valid users.";
         public const string GroupFilterDescription = "The filter to use when searching valid user groups.";
         public const string AllowAutoUserCreationDescription = "Whether unknown users will be automatically created upon successful login.";
-        public const string ReferralFollowingEnabledDescription = "Sets whether to enable referral following.";
-
+        public const string ReferralFollowingEnabledDescription = "Sets whether to allow referral following.";
+        public const string ReferralHopLimitDescription = "Sets the maximum number of referrals to follow during automatic referral following.";
+        public const string ConstraintTimeLimitDescription = "Sets the time limit in ms for LDAP operations on the directory.";
 
         [DisplayName("Server")]
         [Description(ServerDescription)]
@@ -76,10 +77,20 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         [Writeable]
         public bool AllowAutoUserCreation { get; set; }
 
-        [DisplayName("ReferralFollowingEnabledDescription")]
+        [DisplayName("Referral Following Enabled")]
         [Description(ReferralFollowingEnabledDescription)]
         [Writeable]
         public bool ReferralFollowingEnabled { get; set; }
+
+        [DisplayName("Referral Hop Limit")]
+        [Description(ReferralHopLimitDescription)]
+        [Writeable]
+        public static string ReferralHopLimit { get; set; }
+
+        [DisplayName("Constraint Time Limit")]
+        [Description(ConstraintTimeLimitDescription)]
+        [Writeable]
+        public static string ConstraintTimeLimit { get; set; }
 
         [DisplayName("Attribute Mapping")]
         public LdapMappingConfigurationResource AttributeMapping { get; set; } = new LdapMappingConfigurationResource();

--- a/source/Server/Configuration/LdapConfigurationSettings.cs
+++ b/source/Server/Configuration/LdapConfigurationSettings.cs
@@ -36,6 +36,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapUserFilter", ConfigurationDocumentStore.GetUserFilter(), isEnabled, "User Filter");
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapGroupFilter", ConfigurationDocumentStore.GetGroupFilter(), isEnabled, "Group Filter");
             yield return new ConfigurationValue<bool>("Octopus.WebPortal.LdapAllowAutoUserCreation=", ConfigurationDocumentStore.GetAllowAutoUserCreation(), isEnabled, "Allow Auto User Creation");
+            yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapReferralFollowingEnabled", ConfigurationDocumentStore.GetReferralFollowingEnabled().ToString(), isEnabled, "Referral Following Enabled");
+            yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapConstraintTimeLimit", ConfigurationDocumentStore.GetConstraintTimeLimit().ToString(), isEnabled, "Constraint Time Limit");
+            yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapReferralHopLimit", ConfigurationDocumentStore.GetReferralHopLimit().ToString(), isEnabled, "Referral Hop Limit");
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapUserNameAttribute", ConfigurationDocumentStore.GetUserNameAttribute(), isEnabled, "User Name Attribute");
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapUserDisplayNameAttribute", ConfigurationDocumentStore.GetUserDisplayNameAttribute(), isEnabled, "User Display Name Attribute");
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapUserPrincipalNameAttribute", ConfigurationDocumentStore.GetUserPrincipalNameAttribute(), isEnabled, "User Principal Name Attribute");

--- a/source/Server/Configuration/LdapConfigurationStore.cs
+++ b/source/Server/Configuration/LdapConfigurationStore.cs
@@ -186,5 +186,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 
         public bool GetReferralFollowingEnabled() => GetProperty(doc => doc.ReferralFollowingEnabled);
         public void SetReferralFollowingEnabled(bool enabled) => SetProperty(doc => doc.ReferralFollowingEnabled = enabled);
+
+        public int GetReferralHopLimit() => GetProperty(doc => doc.ReferralHopLimit);
+        public void SetReferralHopLimit(int hopLimit) => SetProperty(doc => doc.ReferralHopLimit = hopLimit);
+
+        public int GetConstraintTimeLimit() => GetProperty(doc => doc.ConstraintTimeLimit);
+        public void SetConstraintTimeLimit(int timeLimit) => SetProperty(doc => doc.ConstraintTimeLimit = timeLimit);
+
     }
 }

--- a/source/Server/Configuration/LdapConfigurationStore.cs
+++ b/source/Server/Configuration/LdapConfigurationStore.cs
@@ -183,5 +183,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         {
             SetProperty(doc => doc.AttributeMapping.GroupNameAttribute = groupNameAttribute);
         }
+
+        public bool GetReferralFollowingEnabled() => GetProperty(doc => doc.ReferralFollowingEnabled);
+        public void SetReferralFollowingEnabled(bool enabled) => SetProperty(doc => doc.ReferralFollowingEnabled = enabled);
     }
 }

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -94,7 +94,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ReferralFollowingEnabled specified: {v}.");
+                    log.Warn($"Invalid LDAP ReferralFollowingEnabled specified: {v}. Value must be either 'true', or 'false'.");
                 }
             });
             yield return new ConfigureCommandOption("ldapReferralHopLimit=", LdapConfigurationResource.ReferralHopLimitDescription, v =>
@@ -106,7 +106,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ReferralHopLimit specified: {v}.");
+                    log.Warn($"Invalid LDAP ReferralHopLimit specified: {v}. Value must be a number equal to, or greater than zero.");
                 }
             });
             yield return new ConfigureCommandOption("ldapConstraintTimeLimit=", LdapConfigurationResource.ConstraintTimeLimitDescription, v =>
@@ -118,7 +118,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ConstraintTimeLimit specified: {v}.");
+                    log.Warn($"Invalid LDAP ConstraintTimeLimit specified: {v}. Value must be a number equal to, or greater than zero.");
                 }
             });
 

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -94,31 +94,31 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ReferralFollowingEnabled specified: {v}.  Using default value instead.");
+                    log.Warn($"Invalid LDAP ReferralFollowingEnabled specified: {v}.");
                 }
             });
             yield return new ConfigureCommandOption("ldapReferralHopLimit=", LdapConfigurationResource.ReferralHopLimitDescription, v =>
             {
-                if (int.TryParse(v, out var hopLimit))
+                if (int.TryParse(v, out var hopLimit) && hopLimit >= 0)
                 {
                     ldapConfiguration.Value.SetReferralHopLimit(hopLimit);
                     log.Info("LDAP ReferralHopLimit set to: " + v);
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ReferralHopLimit specified: {v}.  Using default value instead.");
+                    log.Warn($"Invalid LDAP ReferralHopLimit specified: {v}.");
                 }
             });
             yield return new ConfigureCommandOption("ldapConstraintTimeLimit=", LdapConfigurationResource.ConstraintTimeLimitDescription, v =>
             {
-                if (int.TryParse(v, out var timeLimit))
+                if (int.TryParse(v, out var timeLimit) && timeLimit >= 0)
                 {
                     ldapConfiguration.Value.SetConstraintTimeLimit(timeLimit);
                     log.Info("LDAP ConstraintTimeLimit set to: " + v);
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ConstraintTimeLimit specified: {v}.  Using default value instead.");
+                    log.Warn($"Invalid LDAP ConstraintTimeLimit specified: {v}.");
                 }
             });
 

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -102,11 +102,11 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 if (int.TryParse(v, out var hopLimit))
                 {
                     ldapConfiguration.Value.SetReferralHopLimit(hopLimit);
-                    log.Info("LDAP ReferalHopLimit set to: " + v);
+                    log.Info("LDAP ReferralHopLimit set to: " + v);
                 }
                 else
                 {
-                    log.Warn($"Invalid LDAP ReferalHopLimit specified: {v}.  Using default value instead.");
+                    log.Warn($"Invalid LDAP ReferralHopLimit specified: {v}.  Using default value instead.");
                 }
             });
             yield return new ConfigureCommandOption("ldapConstraintTimeLimit=", LdapConfigurationResource.ConstraintTimeLimitDescription, v =>

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -85,6 +85,42 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 ldapConfiguration.Value.SetAllowAutoUserCreation(isAllowed);
                 log.Info("LDAP auto user creation allowed: " + isAllowed);
             });
+            yield return new ConfigureCommandOption("ldapReferralFollowingEnabled=", LdapConfigurationResource.ReferralFollowingEnabledDescription, v =>
+            {
+                if (bool.TryParse(v, out var enabled))
+                {
+                    ldapConfiguration.Value.SetReferralFollowingEnabled(enabled);
+                    log.Info("LDAP ReferralFollowingEnabled set to: " + v);
+                }
+                else
+                {
+                    log.Warn($"Invalid LDAP ReferralFollowingEnabled specified: {v}.  Using default value instead.");
+                }
+            });
+            yield return new ConfigureCommandOption("ldapReferralHopLimit=", LdapConfigurationResource.ReferralHopLimitDescription, v =>
+            {
+                if (int.TryParse(v, out var hopLimit))
+                {
+                    ldapConfiguration.Value.SetReferralHopLimit(hopLimit);
+                    log.Info("LDAP ReferalHopLimit set to: " + v);
+                }
+                else
+                {
+                    log.Warn($"Invalid LDAP ReferalHopLimit specified: {v}.  Using default value instead.");
+                }
+            });
+            yield return new ConfigureCommandOption("ldapConstraintTimeLimit=", LdapConfigurationResource.ConstraintTimeLimitDescription, v =>
+            {
+                if (int.TryParse(v, out var timeLimit))
+                {
+                    ldapConfiguration.Value.SetConstraintTimeLimit(timeLimit);
+                    log.Info("LDAP ConstraintTimeLimit set to: " + v);
+                }
+                else
+                {
+                    log.Warn($"Invalid LDAP ConstraintTimeLimit specified: {v}.  Using default value instead.");
+                }
+            });
 
             yield return new ConfigureCommandOption("ldapUserDisplayNameAttribute=", LdapMappingConfigurationResource.UserDisplayNameAttributeDescription, v =>
             {
@@ -110,11 +146,6 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
             {
                 ldapConfiguration.Value.SetGroupNameAttribute(v);
                 log.Info("LDAP GroupNameAttribute set to: " + v);
-            });
-            yield return new ConfigureCommandOption("ldapReferralFollowingEnabled=", LdapMappingConfigurationResource, v =>
-            {
-                ldapConfiguration.Value.SetGroupNameAttribute(v);
-                log.Info("LDAP ReferralFollowingEnabled set to: " + v);
             });
         }
     }

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -111,6 +111,11 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 ldapConfiguration.Value.SetGroupNameAttribute(v);
                 log.Info("LDAP GroupNameAttribute set to: " + v);
             });
+            yield return new ConfigureCommandOption("ldapReferralFollowingEnabled=", LdapMappingConfigurationResource, v =>
+            {
+                ldapConfiguration.Value.SetGroupNameAttribute(v);
+                log.Info("LDAP ReferralFollowingEnabled set to: " + v);
+            });
         }
     }
 }

--- a/source/Server/Ldap/LdapContextProvider.cs
+++ b/source/Server/Ldap/LdapContextProvider.cs
@@ -35,6 +35,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             var con = new LdapConnection(options);
             con.Connect(ldapConfiguration.Value.GetServer(), ldapConfiguration.Value.GetPort());
             con.Bind(ldapConfiguration.Value.GetConnectUsername(), ldapConfiguration.Value.GetConnectPassword().Value);
+            con.Constraints.ReferralFollowing = ldapConfiguration.Value.GetReferralFollowingEnabled();
 
             return new LdapContext
             {

--- a/source/Server/Ldap/LdapContextProvider.cs
+++ b/source/Server/Ldap/LdapContextProvider.cs
@@ -36,6 +36,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             con.Connect(ldapConfiguration.Value.GetServer(), ldapConfiguration.Value.GetPort());
             con.Bind(ldapConfiguration.Value.GetConnectUsername(), ldapConfiguration.Value.GetConnectPassword().Value);
             con.Constraints.ReferralFollowing = ldapConfiguration.Value.GetReferralFollowingEnabled();
+            con.Constraints.HopLimit = ldapConfiguration.Value.GetReferralHopLimit();
+            con.Constraints.TimeLimit = ldapConfiguration.Value.GetConstraintTimeLimit();
 
             return new LdapContext
             {


### PR DESCRIPTION
Added basic support for LDAP referrals, including the following command line configuration:
 - ldapReferralFollowingEnabled: Sets whether or not to allow referral following.
 - ldapReferralHopLimit: Sets the maximum number of referrals to follow during automatic referral following. Default is 10.
 - ldapConstraintTimeLimit: Sets the time limit in ms for LDAP operations on the directory.  0 [default] specifies no limit.