### PR TITLE
Adding StartTLS support

### DIFF
--- a/source/Server/Configuration/DatabaseInitializer.cs
+++ b/source/Server/Configuration/DatabaseInitializer.cs
@@ -6,10 +6,10 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 {
     public class DatabaseInitializer : ExecuteWhenDatabaseInitializes
     {
-        private readonly ISystemLog log;
+        private readonly ILog log;
         private readonly IConfigurationStore configurationStore;
 
-        public DatabaseInitializer(ISystemLog log, IConfigurationStore configurationStore)
+        public DatabaseInitializer(ILog log, IConfigurationStore configurationStore)
         {
             this.log = log;
             this.configurationStore = configurationStore;

--- a/source/Server/Configuration/ILdapConfigurationStore.cs
+++ b/source/Server/Configuration/ILdapConfigurationStore.cs
@@ -14,6 +14,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         void SetUseSsl(bool useSsl);
         bool GetUseSsl();
 
+        void SetUseStartTls(bool useStartTls);
+        bool GetUseStartTls();
+
         void SetIgnoreSslErrors(bool ignoreSslErrors);
         bool GetIgnoreSslErrors();
 

--- a/source/Server/Configuration/LdapConfiguration.cs
+++ b/source/Server/Configuration/LdapConfiguration.cs
@@ -16,6 +16,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 
         public bool UseSsl { get; set; }
 
+        public bool UseStartTls { get; set; }
+
         public bool IgnoreSslErrors { get; set; }
 
         public string ConnectUsername { get; set; }

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -9,6 +9,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
     {
         public const string ServerDescription = "Set the server URL.";
         public const string PortDescription = "Set the port using to connect.";
+        public const string UseStartTlsDescription = "Sets whether to upgrade to TLS after connecting to LDAP.";
         public const string UseSslDescription = "Sets whether to use Secure Socket Layer to connect to LDAP.";
         public const string IgnoreSslErrorsDescription = "Sets whether to ignore certificate validation errors.";
         public const string UsernameDescription = "Set the user DN to query LDAP.";
@@ -36,6 +37,11 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         [Description(UseSslDescription)]
         [Writeable]
         public bool UseSsl { get; set; }
+
+        [DisplayName("Use StartTLS")]
+        [Description(UseStartTlsDescription)]
+        [Writeable]
+        public bool UseStartTls { get; set; }
 
         [DisplayName("Ignore SSL errors")]
         [Description(IgnoreSslErrorsDescription)]

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -1,7 +1,7 @@
 ﻿using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 using System.ComponentModel;
-using Octopus.Server.MessageContracts;
-using Octopus.Server.MessageContracts.Attributes;
+using Octopus.Data.Resources.Attributes;
+using Octopus.Data.Resources;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 {

--- a/source/Server/Configuration/LdapConfigurationSettings.cs
+++ b/source/Server/Configuration/LdapConfigurationSettings.cs
@@ -28,6 +28,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapServer", ConfigurationDocumentStore.GetServer(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetServer()), "Server");
             yield return new ConfigurationValue<int>("Octopus.WebPortal.LdapPort", ConfigurationDocumentStore.GetPort(), isEnabled, "Port");
             yield return new ConfigurationValue<bool>("Octopus.WebPortal.LdapUseSsl", ConfigurationDocumentStore.GetUseSsl(), isEnabled, "Use SSL");
+            yield return new ConfigurationValue<bool>("Octopus.WebPortal.LdapUseStartTls", ConfigurationDocumentStore.GetUseStartTls(), isEnabled, "Use StartTLS");
             yield return new ConfigurationValue<bool>("Octopus.WebPortal.LdapIgnoreSslErrors", ConfigurationDocumentStore.GetIgnoreSslErrors(), isEnabled, "Ignore SSL errors");
             yield return new ConfigurationValue<string>("Octopus.WebPortal.LdapUsername", ConfigurationDocumentStore.GetConnectUsername(), isEnabled, "Username");
             yield return new ConfigurationValue<SensitiveString>("Octopus.WebPortal.LdapPassword", ConfigurationDocumentStore.GetConnectPassword(), isEnabled, "Password");

--- a/source/Server/Configuration/LdapConfigurationStore.cs
+++ b/source/Server/Configuration/LdapConfigurationStore.cs
@@ -45,6 +45,16 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
             return GetProperty(doc => doc.UseSsl);
         }
 
+        public void SetUseStartTls(bool useStartTls)
+        {
+            SetProperty(doc => doc.UseStartTls = useStartTls);
+        }
+
+        public bool GetUseStartTls()
+        {
+            return GetProperty(doc => doc.UseStartTls);
+        }
+
         public void SetIgnoreSslErrors(bool ignoreSslErrors)
         {
             SetProperty(doc => doc.IgnoreSslErrors = ignoreSslErrors);

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -37,6 +37,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
                 ldapConfiguration.Value.SetPort(port);
                 log.Info("LDAP Port set to: " + port);
             });
+            yield return new ConfigureCommandOption("ldapUseStartTls=", LdapConfigurationResource.UseStartTlsDescription, v =>
+            {
+                bool.TryParse(v, out var useStartTls);
+                ldapConfiguration.Value.SetUseStartTls(useStartTls);
+                log.Info("LDAP UseStartTls set to: " + useStartTls);
+            });
             yield return new ConfigureCommandOption("ldapUseSsl=", LdapConfigurationResource.UseSslDescription, v =>
             {
                 bool.TryParse(v, out var useSsl);

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -7,11 +7,11 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 {
     public class LdapConfigureCommands : IContributeToConfigureCommand
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly Lazy<ILdapConfigurationStore> ldapConfiguration;
 
         public LdapConfigureCommands(
-            ISystemLog log,
+            ILog log,
             Lazy<ILdapConfigurationStore> ldapConfiguration)
         {
             this.log = log;

--- a/source/Server/Identities/IdentityCreator.cs
+++ b/source/Server/Identities/IdentityCreator.cs
@@ -1,5 +1,4 @@
 ﻿using Octopus.Data.Model.User;
-using Octopus.Server.Extensibility.Authentication.Model;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap.Identities

--- a/source/Server/Ldap/GroupRetriever.cs
+++ b/source/Server/Ldap/GroupRetriever.cs
@@ -12,12 +12,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class GroupRetriever : IExternalGroupRetriever
     {
-        private readonly ISystemLog log;
+        private readonly ILog log;
         private readonly ILdapConfigurationStore configurationStore;
         private readonly ILdapExternalSecurityGroupLocator groupLocator;
 
         public GroupRetriever(
-            ISystemLog log,
+            ILog log,
             ILdapConfigurationStore configurationStore,
             ILdapExternalSecurityGroupLocator groupLocator)
         {

--- a/source/Server/Ldap/LdapContext.cs
+++ b/source/Server/Ldap/LdapContext.cs
@@ -27,6 +27,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public void Dispose()
         {
+            if(LdapConnection?.Tls == true)
+                LdapConnection.StopTls();
             LdapConnection?.Dispose();
         }
     }

--- a/source/Server/Ldap/LdapContextProvider.cs
+++ b/source/Server/Ldap/LdapContextProvider.cs
@@ -33,6 +33,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             {
                 var con = new LdapConnection(options);
                 con.Connect(ldapConfiguration.Value.GetServer(), ldapConfiguration.Value.GetPort());
+                if(ldapConfiguration.Value.GetUseStartTls())
+                    con.StartTls();
                 con.Bind(ldapConfiguration.Value.GetConnectUsername(), ldapConfiguration.Value.GetConnectPassword().Value);
                 con.Constraints.ReferralFollowing = ldapConfiguration.Value.GetReferralFollowingEnabled();
                 con.Constraints.HopLimit = ldapConfiguration.Value.GetReferralHopLimit();

--- a/source/Server/Ldap/LdapCredentialValidator.cs
+++ b/source/Server/Ldap/LdapCredentialValidator.cs
@@ -15,7 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapCredentialValidator : ILdapCredentialValidator
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly ILdapObjectNameNormalizer objectNameNormalizer;
         readonly IUpdateableUserStore userStore;
         readonly ILdapConfigurationStore configurationStore;
@@ -28,7 +28,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
         public int Priority => 100;
 
         public LdapCredentialValidator(
-            ISystemLog log,
+            ILog log,
             ILdapObjectNameNormalizer objectNameNormalizer,
             IUpdateableUserStore userStore,
             ILdapConfigurationStore configurationStore,

--- a/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
+++ b/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
@@ -13,7 +13,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapExternalSecurityGroupLocator : ILdapExternalSecurityGroupLocator
     {
-        private readonly ISystemLog log;
+        private readonly ILog log;
         private readonly ILdapContextProvider contextProvider;
         private readonly ILdapObjectNameNormalizer objectNameNormalizer;
         private readonly ILdapConfigurationStore configurationStore;
@@ -22,7 +22,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
         public string IdentityProviderName => LdapAuthentication.ProviderName;
 
         public LdapExternalSecurityGroupLocator(
-            ISystemLog log,
+            ILog log,
             ILdapContextProvider contextProvider,
             ILdapObjectNameNormalizer objectNameNormalizer,
             ILdapConfigurationStore configurationStore,

--- a/source/Server/Ldap/LdapService.cs
+++ b/source/Server/Ldap/LdapService.cs
@@ -9,13 +9,13 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapService : ILdapService
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly ILdapObjectNameNormalizer objectNameNormalizer;
         readonly ILdapContextProvider contextProvider;
         readonly IUserPrincipalFinder userPrincipalFinder;
         readonly ILdapConfigurationStore configurationStore;
 
-        public LdapService(ISystemLog log,
+        public LdapService(ILog log,
             ILdapObjectNameNormalizer objectNameNormalizer,
             ILdapContextProvider contextProvider,
             IUserPrincipalFinder userPrincipalFinder,

--- a/source/Server/Ldap/UserLookup.cs
+++ b/source/Server/Ldap/UserLookup.cs
@@ -4,7 +4,6 @@ using Octopus.Server.Extensibility.Authentication.Ldap.Identities;
 using Octopus.Server.Extensibility.Results;
 using System.Linq;
 using System.Threading;
-using Octopus.Server.Extensibility.Authentication.Model;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap
 {

--- a/source/Server/LdapAuthenticationProvider.cs
+++ b/source/Server/LdapAuthenticationProvider.cs
@@ -1,10 +1,10 @@
-﻿using Octopus.Server.Extensibility.Authentication.Extensions;
+﻿using Octopus.Data.Model;
+using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.Ldap.Configuration;
 using Octopus.Server.Extensibility.Authentication.Ldap.Identities;
 using Octopus.Server.Extensibility.Authentication.Resources;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
-using Octopus.Server.MessageContracts;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap
 {

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.4" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.3" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="12.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Addressing #21 

Still need to verify this works locally, but it seems to be a pretty quick update. 

Other than piping the config option through, it's two things:

1. If `ldapConfiguration.Value.GetUseStartTls()` then after `con.Connect`, call `con.StartTls`. 
> This upgrades the insecure connection to use TLS
2. Before disposing, check `LdapConnection.Tls` which will be set to true if StartTls successfully completed. If so, call `LdapConnection.StopTls` before disposing the connection.
> This appears to be necessary following: https://github.com/dsbenghe/Novell.Directory.Ldap.NETStandard/issues/101