### PR TITLE
Fix startup throwing a `NullReferenceException`

### DIFF
--- a/source/Server/Configuration/LdapConfigurationStore.cs
+++ b/source/Server/Configuration/LdapConfigurationStore.cs
@@ -36,7 +36,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public SensitiveString GetConnectPassword() => GetProperty(doc => doc.ConnectPassword);
         public void SetConnectPassword(SensitiveString password) => SetProperty(doc =>
         {
-            log.WithSensitiveValue(password.Value);
+            if (!string.IsNullOrEmpty(password?.Value))
+                log.WithSensitiveValue(password.Value);
+
             doc.ConnectPassword = password;
         });
 

--- a/source/Server/LdapAuthenticationProvider.cs
+++ b/source/Server/LdapAuthenticationProvider.cs
@@ -19,7 +19,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             this.configurationStore = configurationStore;
             var password = configurationStore.GetConnectPassword();
             
-            if (!string.IsNullOrEmpty(password.Value))
+            if (!string.IsNullOrEmpty(password?.Value))
                 log.WithSensitiveValue(password.Value);
         }
 


### PR DESCRIPTION
An null reference is being thrown in startup in the `ctor` of `LdapAuthenticationProvider` when this extension is bundled.  `password` could be `null` and is not being appropriately checked/guarded