### PR TITLE
Provide a version compatible with Server 2021.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 3.1.x
           
       - name: Nuke Build 🏗
         id: build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Octopus Deploy LDAP Authentication Provider
 
-![continuous](https://github.com/tunger/OctopusDeploy-LdapAuthenticationProvider/workflows/continuous/badge.svg)
+[![Build, Test, Package and Push](https://github.com/OctopusDeploy/LdapAuthenticationProvider/actions/workflows/main.yml/badge.svg)](https://github.com/OctopusDeploy/LdapAuthenticationProvider/actions/workflows/main.yml)
 
-This repository contains a LDAP authentication provider for [Octopus Deploy][1] based on the [Novell.Directory.Ldap.NETStandard][2] library.
+This repository contains an LDAP authentication provider for [Octopus Deploy][1] based on the [Novell.Directory.Ldap.NETStandard][2] library.
+It was originally authored by [@tunger](https://github.com/tunger) and transferred to [@OctopusDeploy](https://github.com/OctopusDeploy) in May 2021
 This project is based on the [Octopus Deploy DirectoryServices authentication provider][3].
+
+## Compatibility
+
+| LDAP Extension Version | Compatible Octopus Server Version | Notes |
+|---|---|---|
+| 0.9 | 2020.6 | Custom Extension.  Last version of community created extension |
+| 1.0 | 2021.1 | Custom Extension.  Officially provided by [@OctopusDeploy](https://github.com/OctopusDeploy) |
 
 ## Installation
 
-1. Grab a release from the [releases page](https://github.com/tunger/OctopusDeploy-LdapAuthenticationProvider/releases).
-2. Install the extension according to [Octopus Deploy documentation][4].
+1. Grab a release from the [releases page](https://github.com/OctopusDeploy/LdapAuthenticationProvider/releases).
+2. Install as a custom extension according to the [Octopus Deploy documentation][4].
 
 ## Configuration
 

--- a/build/Octopus.Server.Extensibility.Authentication.Ldap.nuspec
+++ b/build/Octopus.Server.Extensibility.Authentication.Ldap.nuspec
@@ -19,12 +19,12 @@
     <tags>automation deployment</tags>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <group targetFramework="net5.0">
+      <group targetFramework=".NETStandard2.1">
         <dependency id="Novell.Directory.Ldap.NETStandard" version="3.6.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="..\source\Server\bin\Release\net5.0\*.dll" target="tools" />
+    <file src="..\source\Server\bin\Release\netstandard2.1\*.dll" target="tools" />
   </files>
 </package>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>Octopus.Client.Extensibility.Authentication.Ldap</RootNamespace>
         <AssemblyName>Octopus.Client.Extensibility.Authentication.Ldap</AssemblyName>
         <NeutralLanguage>en-US</NeutralLanguage>

--- a/source/Ldap.Integration.Tests/Ldap.Integration.Tests.csproj
+++ b/source/Ldap.Integration.Tests/Ldap.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/source/Ldap.Integration.Tests/TestHelpers/FixtureHelper.cs
+++ b/source/Ldap.Integration.Tests/TestHelpers/FixtureHelper.cs
@@ -14,7 +14,7 @@ namespace Ldap.Integration.Tests.TestHelpers
             var configurationStore = new FakeLdapConfigurationStore(configuration);
 
             return new UserMatcher(
-                new LdapContextProvider(new Lazy<ILdapConfigurationStore>(() => configurationStore), Substitute.For<ISystemLog>()),
+                new LdapContextProvider(new Lazy<ILdapConfigurationStore>(() => configurationStore), Substitute.For<ILog>()),
                 new LdapObjectNameNormalizer(new Lazy<ILdapConfigurationStore>(() => configurationStore)),
                 configurationStore,
                 new UserPrincipalFinder(),
@@ -26,7 +26,7 @@ namespace Ldap.Integration.Tests.TestHelpers
             var configurationStore = new FakeLdapConfigurationStore(configuration);
             var nameNormalizer = new LdapObjectNameNormalizer(new Lazy<ILdapConfigurationStore>(() => configurationStore));
 
-            var log = Substitute.For<ISystemLog>();
+            var log = Substitute.For<ILog>();
             var ldapService = new LdapService(
                 log,
                 nameNormalizer,
@@ -49,7 +49,7 @@ namespace Ldap.Integration.Tests.TestHelpers
             var configurationStore = new FakeLdapConfigurationStore(configuration);
             var nameNormalizer = new LdapObjectNameNormalizer(new Lazy<ILdapConfigurationStore>(() => configurationStore));
 
-            var log = Substitute.For<ISystemLog>();
+            var log = Substitute.For<ILog>();
             var ldapService = new LdapService(
                 log,
                 nameNormalizer,
@@ -68,7 +68,7 @@ namespace Ldap.Integration.Tests.TestHelpers
         public static GroupRetriever CreateFixtureGroupRetriever(LdapConfiguration configuration)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
-            var log = Substitute.For<ISystemLog>();
+            var log = Substitute.For<ILog>();
 
             var groupLocator = new LdapExternalSecurityGroupLocator(
                 log,
@@ -84,7 +84,7 @@ namespace Ldap.Integration.Tests.TestHelpers
         public static LdapExternalSecurityGroupLocator CreateLdapExternalSecurityGroupLocator(LdapConfiguration configuration)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
-            var log = Substitute.For<ISystemLog>();
+            var log = Substitute.For<ILog>();
 
             return new LdapExternalSecurityGroupLocator(
                 log,
@@ -99,7 +99,7 @@ namespace Ldap.Integration.Tests.TestHelpers
         public static UserSearch CreateUserSearch(LdapConfiguration configuration)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
-            var log = Substitute.For<ISystemLog>();
+            var log = Substitute.For<ILog>();
 
             return new UserSearch(
                 new LdapContextProvider(new Lazy<ILdapConfigurationStore>(() => configurationStore), log),

--- a/source/Ldap.Tests/Ldap.Tests.csproj
+++ b/source/Ldap.Tests/Ldap.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/source/Server/Configuration/DatabaseInitializer.cs
+++ b/source/Server/Configuration/DatabaseInitializer.cs
@@ -6,10 +6,10 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 {
     public class DatabaseInitializer : ExecuteWhenDatabaseInitializes
     {
-        private readonly ISystemLog log;
+        private readonly ILog log;
         private readonly IConfigurationStore configurationStore;
 
-        public DatabaseInitializer(ISystemLog log, IConfigurationStore configurationStore)
+        public DatabaseInitializer(ILog log, IConfigurationStore configurationStore)
         {
             this.log = log;
             this.configurationStore = configurationStore;

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -1,8 +1,7 @@
 ﻿using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 using System.ComponentModel;
-using Octopus.Diagnostics;
-using Octopus.Server.MessageContracts;
-using Octopus.Server.MessageContracts.Attributes;
+using Octopus.Data.Resources;
+using Octopus.Data.Resources.Attributes;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 {

--- a/source/Server/Configuration/LdapConfigurationStore.cs
+++ b/source/Server/Configuration/LdapConfigurationStore.cs
@@ -9,9 +9,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
     public class LdapConfigurationStore : ExtensionConfigurationStore<LdapConfiguration>, ILdapConfigurationStore
     {
         public static string SingletonId = "authentication-ldap";
-        ISystemLog log;
+        ILogWithContext log;
 
-        public LdapConfigurationStore(IConfigurationStore configurationStore, ISystemLog log) : base(configurationStore)
+        public LdapConfigurationStore(IConfigurationStore configurationStore, ILogWithContext log) : base(configurationStore)
         {
             this.log = log;
         }
@@ -37,7 +37,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public void SetConnectPassword(SensitiveString password) => SetProperty(doc =>
         {
             if (!string.IsNullOrEmpty(password?.Value))
-                log.WithSensitiveValue(password.Value);
+                log.CurrentContext.WithSensitiveValue(password.Value);
 
             doc.ConnectPassword = password;
         });

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -7,11 +7,11 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
 {
     public class LdapConfigureCommands : IContributeToConfigureCommand
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly Lazy<ILdapConfigurationStore> ldapConfiguration;
 
         public LdapConfigureCommands(
-            ISystemLog log,
+            ILog log,
             Lazy<ILdapConfigurationStore> ldapConfiguration)
         {
             this.log = log;

--- a/source/Server/Identities/IdentityCreator.cs
+++ b/source/Server/Identities/IdentityCreator.cs
@@ -1,5 +1,4 @@
 ﻿using Octopus.Data.Model.User;
-using Octopus.Server.Extensibility.Authentication.Model;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap.Identities

--- a/source/Server/Ldap/GroupRetriever.cs
+++ b/source/Server/Ldap/GroupRetriever.cs
@@ -13,12 +13,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class GroupRetriever : IExternalGroupRetriever
     {
-        private readonly ISystemLog log;
+        private readonly ILog log;
         private readonly ILdapConfigurationStore configurationStore;
         private readonly ILdapExternalSecurityGroupLocator groupLocator;
 
         public GroupRetriever(
-            ISystemLog log,
+            ILog log,
             ILdapConfigurationStore configurationStore,
             ILdapExternalSecurityGroupLocator groupLocator)
         {

--- a/source/Server/Ldap/LdapContextProvider.cs
+++ b/source/Server/Ldap/LdapContextProvider.cs
@@ -11,9 +11,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     public class LdapContextProvider : ILdapContextProvider
     {
         private readonly Lazy<ILdapConfigurationStore> ldapConfiguration;
-        private readonly ISystemLog log;
+        private readonly ILog log;
 
-        public LdapContextProvider(Lazy<ILdapConfigurationStore> ldapConfiguration, ISystemLog log)
+        public LdapContextProvider(Lazy<ILdapConfigurationStore> ldapConfiguration, ILog log)
         {
             this.ldapConfiguration = ldapConfiguration;
             this.log = log;

--- a/source/Server/Ldap/LdapCredentialValidator.cs
+++ b/source/Server/Ldap/LdapCredentialValidator.cs
@@ -15,7 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapCredentialValidator : ILdapCredentialValidator
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly ILdapObjectNameNormalizer objectNameNormalizer;
         readonly IUpdateableUserStore userStore;
         readonly ILdapConfigurationStore configurationStore;
@@ -28,7 +28,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
         public int Priority => 100;
 
         public LdapCredentialValidator(
-            ISystemLog log,
+            ILog log,
             ILdapObjectNameNormalizer objectNameNormalizer,
             IUpdateableUserStore userStore,
             ILdapConfigurationStore configurationStore,

--- a/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
+++ b/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
@@ -14,7 +14,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapExternalSecurityGroupLocator : ILdapExternalSecurityGroupLocator
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly ILdapContextProvider contextProvider;
         readonly ILdapObjectNameNormalizer objectNameNormalizer;
         readonly ILdapConfigurationStore configurationStore;
@@ -24,7 +24,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
         public string IdentityProviderName => LdapAuthentication.ProviderName;
 
         public LdapExternalSecurityGroupLocator(
-            ISystemLog log,
+            ILog log,
             ILdapContextProvider contextProvider,
             ILdapObjectNameNormalizer objectNameNormalizer,
             ILdapConfigurationStore configurationStore,

--- a/source/Server/Ldap/LdapService.cs
+++ b/source/Server/Ldap/LdapService.cs
@@ -6,12 +6,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapService : ILdapService
     {
-        readonly ISystemLog log;
+        readonly ILog log;
         readonly ILdapObjectNameNormalizer objectNameNormalizer;
         readonly ILdapContextProvider contextProvider;
         readonly IUserPrincipalFinder userPrincipalFinder;
 
-        public LdapService(ISystemLog log,
+        public LdapService(ILog log,
             ILdapObjectNameNormalizer objectNameNormalizer,
             ILdapContextProvider contextProvider,
             IUserPrincipalFinder userPrincipalFinder)

--- a/source/Server/Ldap/Model/GroupDistinguishedName.cs
+++ b/source/Server/Ldap/Model/GroupDistinguishedName.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Octopus.Server.MessageContracts;
 using Octopus.TinyTypes;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap.Model
 {
-    public class GroupDistinguishedName : CaseInsensitiveStringTinyType, IIdTinyType
+    public class GroupDistinguishedName : CaseInsensitiveStringTinyType
     {
         public GroupDistinguishedName(string value)
             : base(value)

--- a/source/Server/Ldap/UserLookup.cs
+++ b/source/Server/Ldap/UserLookup.cs
@@ -4,7 +4,6 @@ using Octopus.Server.Extensibility.Authentication.Ldap.Identities;
 using Octopus.Server.Extensibility.Results;
 using System.Linq;
 using System.Threading;
-using Octopus.Server.Extensibility.Authentication.Model;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap
 {

--- a/source/Server/LdapAuthenticationProvider.cs
+++ b/source/Server/LdapAuthenticationProvider.cs
@@ -1,11 +1,11 @@
-﻿using Octopus.Diagnostics;
+﻿using Octopus.Data.Model;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.Ldap.Configuration;
 using Octopus.Server.Extensibility.Authentication.Ldap.Identities;
 using Octopus.Server.Extensibility.Authentication.Resources;
 using Octopus.Server.Extensibility.Authentication.Resources.Identities;
-using Octopus.Server.MessageContracts;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
@@ -14,13 +14,13 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     {
         private readonly ILdapConfigurationStore configurationStore;
 
-        public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore, ISystemLog log)
+        public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore, ILogWithContext log)
         {
             this.configurationStore = configurationStore;
             var password = configurationStore.GetConnectPassword();
-            
+
             if (!string.IsNullOrEmpty(password?.Value))
-                log.WithSensitiveValue(password.Value);
+                log.CurrentContext.WithSensitiveValue(password.Value);
         }
 
         public string IdentityProviderName => LdapAuthentication.ProviderName;

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.Ldap</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.Ldap</AssemblyName>
     <Description>Implements the LDAP authentication provider.</Description>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -19,9 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
     <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.3" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="12.1.1" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.1" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.5" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.3" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="12.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\images\icon.png">

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
-    <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="12.1.1" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />


### PR DESCRIPTION
The extension will be bundled with Octopus Server 2021.2 but we will provide a 2021.1 compatible version as a downloadable zip bundle on a GitHub release, to be installed as a Custom Extension

Set target frameworks and dependency versions to match Server 2021.1