### PR TITLE
Don't add senstive values in constructor

### DIFF
--- a/source/Server/LdapAuthenticationProvider.cs
+++ b/source/Server/LdapAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿using Octopus.Diagnostics;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.Ldap.Configuration;
@@ -14,13 +14,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     {
         private readonly ILdapConfigurationStore configurationStore;
 
-        public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore, ISystemLog log)
+        public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore)
         {
             this.configurationStore = configurationStore;
-            var password = configurationStore.GetConnectPassword();
-            
-            if (!string.IsNullOrEmpty(password?.Value))
-                log.WithSensitiveValue(password.Value);
         }
 
         public string IdentityProviderName => LdapAuthentication.ProviderName;

--- a/source/Server/LdapAuthenticationProvider.cs
+++ b/source/Server/LdapAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-using Octopus.Diagnostics;
+﻿using System;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
 using Octopus.Server.Extensibility.Authentication.Ldap.Configuration;
@@ -12,7 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     public class LdapAuthenticationProvider : IAuthenticationProviderWithGroupSupport,
         IUseAuthenticationIdentities
     {
-        private readonly ILdapConfigurationStore configurationStore;
+        readonly ILdapConfigurationStore configurationStore;
 
         public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore)
         {
@@ -27,7 +27,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public AuthenticationProviderElement GetAuthenticationProviderElement()
         {
-            return new AuthenticationProviderElement
+            return new()
             {
                 Name = IdentityProviderName,
                 IdentityType = IdentityType.ActiveDirectory,
@@ -37,7 +37,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public AuthenticationProviderThatSupportsGroups GetGroupLookupElement()
         {
-            return new AuthenticationProviderThatSupportsGroups
+            return new()
             {
                 Name = IdentityProviderName,
                 IsRoleBased = false,
@@ -48,12 +48,12 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public string[] GetAuthenticationUrls()
         {
-            return new string[0];
+            return Array.Empty<string>();
         }
 
         public IdentityMetadataResource GetMetadata()
         {
-            return new IdentityMetadataResource
+            return new()
             {
                 IdentityProviderName = IdentityProviderName,
                 ClaimDescriptors = new[]


### PR DESCRIPTION
If the LDAP configuration hasn't yet been initialise (ie first run) this will throw an exception.
I think ideally sensitive values will be added to the log context by covention. Looking to do this in the extension repository.
See discussion here: https://octopusdeploy.slack.com/archives/C01J6U3MHJ4/p1626932316388000