### PR TITLE
Add support for anonymous binding

### DIFF
--- a/source/Client/Configuration/LdapConfigurationResource.cs
+++ b/source/Client/Configuration/LdapConfigurationResource.cs
@@ -17,7 +17,7 @@ namespace Octopus.Client.Extensibility.Authentication.Ldap.Configuration
         public const string UseSslDescription = "Sets whether to use Secure Socket Layer to connect to LDAP.";
         public const string IgnoreSslErrorsDescription = "Sets whether to ignore certificate validation errors.";
         public const string UsernameDescription = "Set the user DN to query LDAP.";
-        public const string PasswordDescription = "Set the password to query LDAP.";
+        public const string PasswordDescription = "Set the password to query LDAP (leave empty for anonymous bind).";
         public const string UserBaseDnDescription = "Set the root distinguished name (DN) to query LDAP for Users.";
         public const string DefaultDomainDescription = "Set the default domain when none is given in the logon form. Optional.";
         public const string UserFilterDescription = "The filter to use when searching valid users.";

--- a/source/Ldap.Integration.Tests/TestHelpers/LdapConfigurationExtensions.cs
+++ b/source/Ldap.Integration.Tests/TestHelpers/LdapConfigurationExtensions.cs
@@ -18,7 +18,7 @@ namespace Ldap.Integration.Tests.TestHelpers
             configuration.Server = server ?? throw new ArgumentNullException(nameof(server));
             configuration.Port = port;
             configuration.ConnectUsername = user ?? throw new ArgumentNullException(nameof(user));
-            configuration.ConnectPassword = password.ToSensitiveString() ?? throw new ArgumentNullException(nameof(password));
+            configuration.ConnectPassword = password?.ToSensitiveString();
 
             return configuration;
         }

--- a/source/Server/Configuration/LdapConfigurationResource.cs
+++ b/source/Server/Configuration/LdapConfigurationResource.cs
@@ -12,7 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
         public const string SecurityProtocolDescription = "Sets the security protocol to use in securing the connection (None, StartTLS, or SSL).";
         public const string IgnoreSslErrorsDescription = "Sets whether to ignore certificate validation errors.";
         public const string UsernameDescription = "Set the user DN to query LDAP.";
-        public const string PasswordDescription = "Set the password to query LDAP.";
+        public const string PasswordDescription = "Set the password to query LDAP (leave empty for anonymous bind).";
         public const string UserBaseDnDescription = "Set the root distinguished name (DN) to query LDAP for Users.";
         public const string DefaultDomainDescription = "Set the default domain when none is given in the logon form. Optional.";
         public const string UserFilterDescription = "The filter to use when searching valid users.  '*' is replaced with a normalized version of the username.";

--- a/source/Server/Configuration/LdapConfigureCommands.cs
+++ b/source/Server/Configuration/LdapConfigureCommands.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Diagnostics;
+﻿using Octopus.Data.Model;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 using System;
 using System.Collections.Generic;
@@ -59,6 +60,19 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap.Configuration
             {
                 ldapConfiguration.Value.SetConnectUsername(v);
                 log.Info("LDAP Username set to: " + v);
+            });
+            yield return new ConfigureCommandOption("ldapPassword=", LdapConfigurationResource.PasswordDescription, v =>
+            {
+                if (!string.IsNullOrEmpty(v))
+                {
+                    ldapConfiguration.Value.SetConnectPassword(v.ToSensitiveString());
+                    log.Info("LDAP Password set to provided value");
+                }
+                else
+                {
+                    ldapConfiguration.Value.SetConnectPassword(null);
+                    log.Info("LDAP Password set to null (anonymous bind)");
+                }
             });
             yield return new ConfigureCommandOption("ldapUserBaseDn=", LdapConfigurationResource.UserBaseDnDescription, v =>
             {

--- a/source/Server/Ldap/LdapContextProvider.cs
+++ b/source/Server/Ldap/LdapContextProvider.cs
@@ -42,7 +42,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
                 if (ldapConfiguration.Value.GetSecurityProtocol() == SecurityProtocol.StartTLS)
                     con.StartTls();
 
-                con.Bind(ldapConfiguration.Value.GetConnectUsername(), ldapConfiguration.Value.GetConnectPassword().Value);
+                con.Bind(ldapConfiguration.Value.GetConnectUsername(), ldapConfiguration.Value.GetConnectPassword()?.Value);
 
                 con.Constraints = new LdapConstraints(
                     ldapConfiguration.Value.GetConstraintTimeLimit() * 1000,

--- a/source/Server/LdapAuthenticationProvider.cs
+++ b/source/Server/LdapAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿using Octopus.Data.Model;
+using Octopus.Data.Model;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Extensions.Identities;
@@ -14,13 +14,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     {
         private readonly ILdapConfigurationStore configurationStore;
 
-        public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore, ILogWithContext log)
+        public LdapAuthenticationProvider(ILdapConfigurationStore configurationStore)
         {
             this.configurationStore = configurationStore;
-            var password = configurationStore.GetConnectPassword();
-
-            if (!string.IsNullOrEmpty(password?.Value))
-                log.CurrentContext.WithSensitiveValue(password.Value);
         }
 
         public string IdentityProviderName => LdapAuthentication.ProviderName;


### PR DESCRIPTION
Fixes #44 

This hotfix for the 1,x release (custom extension for Octopus 2021.1) will subsequently be merged forward through 2.x (bundled in Octopus 2021.2) and finally `main` (to be bundled into OctopusServer vNext)

Also backported a change from 2.x+ that caused a failure on startup in edge cases where ldap configuration was uninitialized