### PR TITLE
Upgrade build to latest Nuke + OctoVersion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,5 +72,6 @@ jobs:
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
-          packages: Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
+          packages: |-
+            Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
             Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Create Release in Octopus 🐙
         uses: OctopusDeploy/create-release-action@v1.1.1
         with:
-          debug: true
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,19 @@ jobs:
             --OctoVersionBranch ${{ github.head_ref || github.ref }} \
             --OctoVersionPatch ${{ github.run_number }}
 
+      - name: Tag release (when not pre-release) 🏷️
+        if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.build.outputs.octoversion_fullsemver }}",
+              sha: context.sha
+            })
+
       - name: Install Octopus CLI 🐙
         uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           version: latest
       
       - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v1.1.0
+        uses: OctopusDeploy/push-package-action@v1.1.1
         with:
           server: https://deploy.octopus.app
           space: Integrations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,5 @@ jobs:
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
-          packages: |
-            Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
+          packages: Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
             Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,12 @@ jobs:
             })
 
       - name: Install Octopus CLI 🐙
-        uses: OctopusDeploy/install-octopus-cli-action@v1
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.6
         with:
           version: latest
       
       - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v1
+        uses: OctopusDeploy/push-package-action@v1.0.2
         with:
           server: https://deploy.octopus.app
           space: Integrations
@@ -63,7 +63,7 @@ jobs:
           packages: ${{ steps.build.outputs.packages_to_push }}
 
       - name: Create Release in Octopus 🐙
-        uses: OctopusDeploy/create-release@v1
+        uses: OctopusDeploy/create-release@v1.0.4
         with:
           server: https://deploy.octopus.app
           space: Integrations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,13 +60,15 @@ jobs:
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
-          packages: ${{ steps.build.outputs.packages_to_push }}
+          packages: "./artifacts/Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}.nupkg,./artifacts/Octopus.Server.Extensibility.Authentication.Ldsp:${{ steps.build.outputs.octoversion_fullsemver }}.nupkg"
 
       - name: Create Release in Octopus 🐙
-        uses: OctopusDeploy/create-release-action@v1.0.4
+        uses: OctopusDeploy/create-release-action@v1.1.0
         with:
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
-          package: ${{ steps.build.outputs.package_versions }}
+          packages: |
+           Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
+           Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,12 @@ jobs:
       - name: Nuke Build 🏗
         id: build
         shell: bash
-        run: ./build.sh --verbosity verbose
-        env:
-          OCTOVERSION_CurrentBranch:  ${{ github.head_ref || github.ref }} # For pull_request events we override the /refs/pull/xx/merge branch to the PR's head branch
-          OCTOVERSION_Patch : ${{ github.run_number }}
+        # Pass branch and patch number to Nuke OctoVersion 
+        # (for pull_request events we override the /refs/pull/xx/merge branch to the PR's head branch)
+        run: |
+          ./build.sh \
+            --OctoVersionBranch ${{ github.head_ref || github.ref }} \
+            --OctoVersionPatch ${{ github.run_number }}
 
       - name: Install Octopus CLI 🐙
         uses: OctopusDeploy/install-octopus-cli-action@v1.1.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,4 @@ jobs:
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
-          package:
-            - "Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}"
-            - "Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}"
+          package: "Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }},Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
             })
 
       - name: Install Octopus CLI 🐙
-        uses: OctopusDeploy/install-octopus-cli-action@v1.1.6
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.7
         with:
           version: latest
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,4 +69,4 @@ jobs:
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
-          package: "Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }},Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}"
+          package: ${{ steps.build.outputs.package_versions }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,12 @@ jobs:
             })
 
       - name: Install Octopus CLI 🐙
-        uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
+        uses: OctopusDeploy/install-octopus-cli-action@v1
         with:
           version: latest
       
       - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v1.0.1
+        uses: OctopusDeploy/push-package-action@v1
         with:
           server: https://deploy.octopus.app
           space: Integrations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,13 +65,13 @@ jobs:
             ./artifacts/Octopus.Server.Extensibility.Authentication.Ldap.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
 
       - name: Create Release in Octopus 🐙
-        uses: OctopusDeploy/create-release-action@v1.1.0
+        uses: OctopusDeploy/create-release-action@v1.1.1
         with:
           debug: true
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
-          packages: |-
+          packages: |
             Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
             Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Create Release in Octopus 🐙
         uses: OctopusDeploy/create-release-action@v1.1.0
         with:
+          debug: true
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           packages: ${{ steps.build.outputs.packages_to_push }}
 
       - name: Create Release in Octopus 🐙
-        uses: OctopusDeploy/create-release@v1.0.4
+        uses: OctopusDeploy/create-release-action@v1.0.4
         with:
           server: https://deploy.octopus.app
           space: Integrations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,14 @@ jobs:
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           packages: ${{ steps.build.outputs.packages_to_push }}
+
+      - name: Create Release in Octopus 🐙
+        uses: OctopusDeploy/create-release@v1
+        with:
+          server: https://deploy.octopus.app
+          space: Integrations
+          api_key: ${{ secrets.DEPLOY_API_KEY }}
+          project: "LdapAuthenticationProvider"
+          package:
+            - "Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}"
+            - "Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,12 +55,14 @@ jobs:
           version: latest
       
       - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v1.0.2
+        uses: OctopusDeploy/push-package-action@v1.1.0
         with:
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
-          packages: "./artifacts/Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}.nupkg,./artifacts/Octopus.Server.Extensibility.Authentication.Ldsp:${{ steps.build.outputs.octoversion_fullsemver }}.nupkg"
+          packages: |
+            ./artifacts/Octopus.Client.Extensibility.Authentication.Ldap.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
+            ./artifacts/Octopus.Server.Extensibility.Authentication.Ldap.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
 
       - name: Create Release in Octopus 🐙
         uses: OctopusDeploy/create-release-action@v1.1.0
@@ -70,5 +72,5 @@ jobs:
           api_key: ${{ secrets.DEPLOY_API_KEY }}
           project: "LdapAuthenticationProvider"
           packages: |
-           Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
-           Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
+            Octopus.Client.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}
+            Octopus.Server.Extensibility.Authentication.Ldap:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -38,6 +38,24 @@
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
         },
+        "OctoVersionAutoDetectBranch": {
+          "type": "boolean"
+        },
+        "OctoVersionBranch": {
+          "type": "string"
+        },
+        "OctoVersionFullSemVer": {
+          "type": "integer"
+        },
+        "OctoVersionMajor": {
+          "type": "integer"
+        },
+        "OctoVersionMinor": {
+          "type": "integer"
+        },
+        "OctoVersionPatch": {
+          "type": "integer"
+        },
         "Partition": {
           "type": "string",
           "description": "Partition to use on CI"
@@ -63,7 +81,6 @@
           "items": {
             "type": "string",
             "enum": [
-              "CalculateVersion",
               "Clean",
               "Compile",
               "CopyToLocalPackages",
@@ -85,7 +102,6 @@
           "items": {
             "type": "string",
             "enum": [
-              "CalculateVersion",
               "Clean",
               "Compile",
               "CopyToLocalPackages",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -85,7 +85,6 @@
               "Compile",
               "CopyToLocalPackages",
               "Default",
-              "OutputPackagesToPush",
               "Pack",
               "Restore",
               "Test"
@@ -106,7 +105,6 @@
               "Compile",
               "CopyToLocalPackages",
               "Default",
-              "OutputPackagesToPush",
               "Pack",
               "Restore",
               "Test"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Linq;
 using Nuke.Common;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
@@ -125,34 +123,8 @@ class Build : NukeBuild
                 });
         });
 
-    Target OutputPackagesToPush => _ => _
-        .DependsOn(Pack)
-        .Executes(() =>
-        {
-            // Create an output variable containing comma separated package files for GH Actions to pass to the push-package-action
-            var artifactPaths = ArtifactsDirectory.GlobFiles("*.nupkg")
-                .NotEmpty()
-                .Select(p => p.ToString())
-                .OrderBy(x => x);
-
-            System.Console.WriteLine($"::set-output name=packages_to_push::{string.Join(',', artifactPaths)}");
-
-            // Create an output variable containing comma separated packageName:version entries for GH Actions to pass to the create-release-action
-            var packageNamesAndVersions = ArtifactsDirectory.GlobFiles("*.nupkg")
-                .NotEmpty()
-                .Select(p =>
-                {
-                    var packageName = Path.GetFileNameWithoutExtension(p).Replace($".{OctoVersionInfo.FullSemVer}", "");
-
-                    return $"{packageName}:{OctoVersionInfo.FullSemVer}";
-                })
-                .OrderBy(x => x);
-
-            System.Console.WriteLine($"::set-output name=package_versions::{string.Join(',', packageNamesAndVersions)}");
-        });
-
     Target Default => _ => _
-        .DependsOn(OutputPackagesToPush);
+        .DependsOn(Pack);
 
     /// Support plugins are available for:
     /// - JetBrains ReSharper        https://nuke.build/resharper

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -130,7 +130,8 @@ class Build : NukeBuild
         {
             var artifactPaths = ArtifactsDirectory.GlobFiles("*.nupkg")
                 .NotEmpty()
-                .Select(p => p.ToString());
+                .Select(p => p.ToString())
+                .OrderBy(x => x);
 
             System.Console.WriteLine($"::set-output name=packages_to_push::{string.Join(',', artifactPaths)}");
         });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,15 +1,13 @@
 using System.Linq;
 using Nuke.Common;
-using Nuke.Common.CI;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
-using OctoVersion.Core;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
-using Nuke.OctoVersion;
+using Nuke.Common.Tools.OctoVersion;
 
 [CheckBuildProjectConfigurations]
 [UnsetVisualStudioEnvironmentVariables]
@@ -19,7 +17,22 @@ class Build : NukeBuild
 
     [Solution] readonly Solution Solution;
 
-    [NukeOctoVersion] readonly OctoVersionInfo OctoVersionInfo;
+    [Parameter] readonly bool? OctoVersionAutoDetectBranch = NukeBuild.IsLocalBuild;
+    [Parameter] readonly string OctoVersionBranch;
+    [Parameter] readonly int? OctoVersionFullSemVer;
+    [Parameter] readonly int? OctoVersionMajor;
+    [Parameter] readonly int? OctoVersionMinor;
+    [Parameter] readonly int? OctoVersionPatch;
+
+    [Required]
+    [OctoVersion(
+        AutoDetectBranchParameter = nameof(OctoVersionAutoDetectBranch),
+        BranchParameter = nameof(OctoVersionBranch),
+        FullSemVerParameter = nameof(OctoVersionFullSemVer),
+        MajorParameter = nameof(OctoVersionMajor),
+        MinorParameter = nameof(OctoVersionMinor),
+        PatchParameter = nameof(OctoVersionPatch))]
+    readonly OctoVersionInfo OctoVersionInfo;
 
     static AbsolutePath SourceDirectory => RootDirectory / "source";
     static AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
@@ -33,12 +46,6 @@ class Build : NukeBuild
             SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(DeleteDirectory);
             EnsureCleanDirectory(ArtifactsDirectory);
             EnsureCleanDirectory(PublishDirectory);
-        });
-
-    Target CalculateVersion => _ => _
-        .Executes(() =>
-        {
-            //all the magic happens inside `[NukeOctoVersion]` above. we just need a target for TeamCity to call
         });
 
     Target Restore => _ => _

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,8 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.2.1" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.438" />
+    <PackageReference Include="Nuke.Common" Version="5.4.0-mattr-octoversio0017" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.685]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Using the latest Nuke, OctoVersion changes allows us to access the OctoVersion calculated `fullsemver` version number within steps in the github action.  
This means the GitHub Actions pipeline can now
- pass in the required OctoVersion settings rather than have to set environment variables
- tag the releases in GitHub (for non pre release builds)
- know the name of the package files (including versions) to be pushed to octopus
- create the Octopus release with the correct versions (instead of relying on Automatic Release Creation trigger which has prevented using channel versioning rules and CaC)

Updating to the latest Octopus GitHub Actions versions allows us to use multiline parameters for `packages` making these more readable/maintainable and specified in the workflow yaml file itself

As part of this change, the Octopus project has had ARC removed and channel versioning rules configured to correctly handle Pre Release vs Default channels 🎉 