### PR TITLE
Escape special characters in Ldap filters and enhance integration tests to cover a range of known DN and filter special characters

### DIFF
--- a/source/Ldap.Integration.Tests/ICanMatchExternalUserTests.cs
+++ b/source/Ldap.Integration.Tests/ICanMatchExternalUserTests.cs
@@ -37,26 +37,6 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
-            internal void MatchesAUserFromActiveDirectoryWithSpecialCharacters()
-            {
-                var userName = "special#1";
-                var expectedUpn = "special#1@mycompany.local";
-                var expectedUan = "special#1";
-                var expectedEmail = "special#1@mycompany.local";
-                var expectedDisplayName = "Special User #1";
-
-                ICanMatchExternalUser fixture = FixtureHelper.CreateUserMatcher(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
-
-                var match = fixture.Match(userName, new CancellationToken());
-
-                Assert.NotNull(match);
-                Assert.Equal(expectedUan, match.Claims["uan"].Value);
-                Assert.Equal(expectedUpn, match.Claims["upn"].Value);
-                Assert.Equal(expectedEmail, match.Claims["email"].Value);
-                Assert.Equal(expectedDisplayName, match.Claims["dn"].Value);
-            }
-
-            [Fact]
             internal void MatchesAUserFromOpenLDAP()
             {
                 var userName = "developer1";

--- a/source/Ldap.Integration.Tests/ICanMatchExternalUserTests.cs
+++ b/source/Ldap.Integration.Tests/ICanMatchExternalUserTests.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using Ldap.Integration.Tests.TestHelpers;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests
 {
@@ -9,6 +10,12 @@ namespace Ldap.Integration.Tests
     {
         public class TheMatchMethod
         {
+            readonly ITestOutputHelper _testLogger;
+            public TheMatchMethod(ITestOutputHelper testLogger)
+            {
+                _testLogger = testLogger;
+            }
+
             [Fact]
             internal void MatchesAUserFromActiveDirectory()
             {
@@ -18,7 +25,7 @@ namespace Ldap.Integration.Tests
                 var expectedEmail = "developer1@mycompany.local";
                 var expectedDisplayName = "Developer User 1";
 
-                ICanMatchExternalUser fixture = FixtureHelper.CreateUserMatcher(ConfigurationHelper.GetActiveDirectoryConfiguration());
+                ICanMatchExternalUser fixture = FixtureHelper.CreateUserMatcher(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
 
                 var match = fixture.Match(userName, new CancellationToken());
 
@@ -38,7 +45,7 @@ namespace Ldap.Integration.Tests
                 var expectedEmail = "developer1@gmail.com";
                 var expectedDisplayName = "Developer User 1";
 
-                ICanMatchExternalUser fixture = FixtureHelper.CreateUserMatcher(ConfigurationHelper.GetOpenLdapConfiguration());
+                ICanMatchExternalUser fixture = FixtureHelper.CreateUserMatcher(ConfigurationHelper.GetOpenLdapConfiguration(), _testLogger);
 
                 var match = fixture.Match(userName, new CancellationToken());
 

--- a/source/Ldap.Integration.Tests/ICanMatchExternalUserTests.cs
+++ b/source/Ldap.Integration.Tests/ICanMatchExternalUserTests.cs
@@ -37,6 +37,26 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
+            internal void MatchesAUserFromActiveDirectoryWithSpecialCharacters()
+            {
+                var userName = "special#1";
+                var expectedUpn = "special#1@mycompany.local";
+                var expectedUan = "special#1";
+                var expectedEmail = "special#1@mycompany.local";
+                var expectedDisplayName = "Special User #1";
+
+                ICanMatchExternalUser fixture = FixtureHelper.CreateUserMatcher(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
+
+                var match = fixture.Match(userName, new CancellationToken());
+
+                Assert.NotNull(match);
+                Assert.Equal(expectedUan, match.Claims["uan"].Value);
+                Assert.Equal(expectedUpn, match.Claims["upn"].Value);
+                Assert.Equal(expectedEmail, match.Claims["email"].Value);
+                Assert.Equal(expectedDisplayName, match.Claims["dn"].Value);
+            }
+
+            [Fact]
             internal void MatchesAUserFromOpenLDAP()
             {
                 var userName = "developer1";

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -37,6 +37,25 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
+            internal void FindsGroupsFromActiveDirectoryWithSpecialCharacters()
+            {
+                var partialName = "Special";
+
+                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
+
+                var result = fixture.Search(partialName, new CancellationToken());
+                
+                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
+                var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
+
+                Assert.Equal(4, searchResult.Groups.Length);
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup (with brackets),ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\# with a hash,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\, with a comma,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
+            }
+
+            [Fact]
             internal void FindsGroupsFromOpenLDAP()
             {
                 var partialName = "Devel";

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -48,10 +48,9 @@ namespace Ldap.Integration.Tests
                 ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
                 var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
 
-                Assert.Equal(4, searchResult.Groups.Length);
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup (with brackets),ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\# with a hash,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\, with a comma,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Equal(3, searchResult.Groups.Length);
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup Parent,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup \\, \\\\ \\# \\+ \\< \\> \\; \\\" \\=,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
             }
 

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -84,10 +84,9 @@ namespace Ldap.Integration.Tests
                 ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
                 var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
 
-                Assert.Equal(4, searchResult.Groups.Length);
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup (with brackets),ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup# with a hash,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\2C with a comma,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Equal(3, searchResult.Groups.Length);
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup Parent,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup \\2C \\5C # \\2B \\3C \\3E \\3B \\22 \\3D,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
             }
         }

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Linq;
 using System.Threading;
 using Ldap.Integration.Tests.TestHelpers;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Results;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests
 {
@@ -12,12 +12,18 @@ namespace Ldap.Integration.Tests
     {
         public class TheSearchMethod
         {
+            readonly ITestOutputHelper _testLogger;
+            public TheSearchMethod(ITestOutputHelper testLogger)
+            {
+                _testLogger = testLogger;
+            }
+
             [Fact]
             internal void FindsGroupsFromActiveDirectory()
             {
                 var partialName = "Devel";
 
-                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetActiveDirectoryConfiguration());
+                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
 
                 var result = fixture.Search(partialName, new CancellationToken());
                 
@@ -35,7 +41,7 @@ namespace Ldap.Integration.Tests
             {
                 var partialName = "Devel";
                 
-                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetOpenLdapConfiguration());
+                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetOpenLdapConfiguration(), _testLogger);
 
                 var result = fixture.Search(partialName, new CancellationToken());
 

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -48,6 +48,7 @@ namespace Ldap.Integration.Tests
                 ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
                 var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
 
+                // Note that ActiveDirectory returns the reserved DN characters in escaped backslashformat, eg \, for , (comma)
                 Assert.Equal(3, searchResult.Groups.Length);
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup Parent,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup \\, \\\\ \\# \\+ \\< \\> \\; \\\" \\=,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
@@ -84,6 +85,7 @@ namespace Ldap.Integration.Tests
                 ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
                 var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
 
+                // Note that openLdap returns the reserved DN characters in escaped hex format, eg \2C for , (comma) and strangely doesnt encode the pound (#) symbol
                 Assert.Equal(3, searchResult.Groups.Length);
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup Parent,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup \\2C \\5C # \\2B \\3C \\3E \\3B \\22 \\3D,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -72,6 +72,25 @@ namespace Ldap.Integration.Tests
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=DeveloperGroup1,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
                 Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=DeveloperGroup2,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
             }
+
+            [Fact]
+            internal void FindsGroupsFromOpenLDAPWithSpecialCharacters()
+            {
+                var partialName = "Special";
+                
+                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetOpenLdapConfiguration(), _testLogger);
+
+                var result = fixture.Search(partialName, new CancellationToken());
+
+                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
+                var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
+
+                Assert.Equal(4, searchResult.Groups.Length);
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup (with brackets),ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup# with a hash,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\2C with a comma,ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=domain1,dc=local", StringComparison.InvariantCultureIgnoreCase));
+            }
         }
     }
 }

--- a/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalGroupsTests.cs
@@ -37,25 +37,6 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
-            internal void FindsGroupsFromActiveDirectoryWithSpecialCharacters()
-            {
-                var partialName = "Special";
-
-                ICanSearchExternalGroups fixture = FixtureHelper.CreateLdapExternalSecurityGroupLocator(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
-
-                var result = fixture.Search(partialName, new CancellationToken());
-                
-                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
-                var searchResult = ((ResultFromExtension<ExternalSecurityGroupResult>)result).Value;
-
-                Assert.Equal(4, searchResult.Groups.Length);
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup (with brackets),ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\# with a hash,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup\\, with a comma,ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
-                Assert.Contains(searchResult.Groups, x => x.Id.Equals("cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=mycompany,dc=local", StringComparison.InvariantCultureIgnoreCase));
-            }
-
-            [Fact]
             internal void FindsGroupsFromOpenLDAP()
             {
                 var partialName = "Devel";

--- a/source/Ldap.Integration.Tests/ICanSearchExternalUsersTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalUsersTests.cs
@@ -1,9 +1,9 @@
-using System.Linq;
 using System.Threading;
 using Ldap.Integration.Tests.TestHelpers;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Results;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests
 {
@@ -11,12 +11,18 @@ namespace Ldap.Integration.Tests
     {
         public class TheSearchMethod
         {
+            readonly ITestOutputHelper _testLogger;
+            public TheSearchMethod(ITestOutputHelper testLogger)
+            {
+                _testLogger = testLogger;
+            }
+
             [Fact]
             internal void FindsUsersFromActiveDirectory()
             {
                 var partialName = "devel";
 
-                ICanSearchExternalUsers fixture = FixtureHelper.CreateUserSearch(ConfigurationHelper.GetActiveDirectoryConfiguration());
+                ICanSearchExternalUsers fixture = FixtureHelper.CreateUserSearch(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
 
                 var result = fixture.Search(partialName, new CancellationToken());
 
@@ -33,7 +39,7 @@ namespace Ldap.Integration.Tests
             {
                 var partialName = "devel";
                 
-                ICanSearchExternalUsers fixture = FixtureHelper.CreateUserSearch(ConfigurationHelper.GetOpenLdapConfiguration());
+                ICanSearchExternalUsers fixture = FixtureHelper.CreateUserSearch(ConfigurationHelper.GetOpenLdapConfiguration(), _testLogger);
 
                 var result = fixture.Search(partialName, new CancellationToken());
 

--- a/source/Ldap.Integration.Tests/ICanSearchExternalUsersTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalUsersTests.cs
@@ -35,22 +35,6 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
-            internal void FindsUsersFromActiveDirectoryWithSpecialCharacters()
-            {
-                var partialName = "special";
-
-                ICanSearchExternalUsers fixture = FixtureHelper.CreateUserSearch(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
-
-                var result = fixture.Search(partialName, new CancellationToken());
-
-                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
-                var searchResult = ((ResultFromExtension<ExternalUserLookupResult>)result).Value;
-
-                Assert.Single(searchResult.Identities);
-                Assert.Contains(searchResult.Identities, x => x.Claims["uan"].Value == "special#1");
-            }
-
-            [Fact]
             internal void FindsUsersFromOpenLDAP()
             {
                 var partialName = "devel";

--- a/source/Ldap.Integration.Tests/ICanSearchExternalUsersTests.cs
+++ b/source/Ldap.Integration.Tests/ICanSearchExternalUsersTests.cs
@@ -35,6 +35,22 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
+            internal void FindsUsersFromActiveDirectoryWithSpecialCharacters()
+            {
+                var partialName = "special";
+
+                ICanSearchExternalUsers fixture = FixtureHelper.CreateUserSearch(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
+
+                var result = fixture.Search(partialName, new CancellationToken());
+
+                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
+                var searchResult = ((ResultFromExtension<ExternalUserLookupResult>)result).Value;
+
+                Assert.Single(searchResult.Identities);
+                Assert.Contains(searchResult.Identities, x => x.Claims["uan"].Value == "special#1");
+            }
+
+            [Fact]
             internal void FindsUsersFromOpenLDAP()
             {
                 var partialName = "devel";

--- a/source/Ldap.Integration.Tests/IDoesBasicAuthenticationTests.cs
+++ b/source/Ldap.Integration.Tests/IDoesBasicAuthenticationTests.cs
@@ -45,31 +45,6 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
-            internal void ValidatesAUserFromActiveDirectoryWithSpecialCharacters()
-            {
-                // Arrange
-                var userName = "special#1";
-                var password = "devp@ss01!";
-
-                IDoesBasicAuthentication fixture = FixtureHelper.CreateLdapCredentialValidator(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName, _testLogger);
-
-                // Act
-                var result = fixture.ValidateCredentials(userName, password, new CancellationToken());
-
-                // Assert
-                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
-                var user = ((ResultFromExtension<IUser>)result).Value;
-
-                Assert.Equal("special#1@mycompany.local", user.Username);
-                Assert.Equal("Special User #1", user.DisplayName);
-                Assert.Equal("special#1@mycompany.local", user.EmailAddress);
-                Assert.Equal("special#1", user.Identities.First().Claims["uan"].Value);
-                Assert.Equal("special#1@mycompany.local", user.Identities.First().Claims["upn"].Value);
-                Assert.Equal("special#1@mycompany.local", user.Identities.First().Claims["email"].Value);
-                Assert.Equal("Special User #1", user.Identities.First().Claims["dn"].Value);
-            }
-
-            [Fact]
             internal void ValidatesAUserFromOpenLDAP()
             {
                 // Arrange

--- a/source/Ldap.Integration.Tests/IDoesBasicAuthenticationTests.cs
+++ b/source/Ldap.Integration.Tests/IDoesBasicAuthenticationTests.cs
@@ -5,6 +5,7 @@ using Octopus.Data.Model.User;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Results;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests
 {
@@ -12,6 +13,12 @@ namespace Ldap.Integration.Tests
     {
         public class TheValidateCredentialsMethod
         {
+            readonly ITestOutputHelper _testLogger;
+            public TheValidateCredentialsMethod(ITestOutputHelper testLogger)
+            {
+                _testLogger = testLogger;
+            }
+
             [Fact]
             internal void ValidatesAUserFromActiveDirectory()
             {
@@ -19,7 +26,7 @@ namespace Ldap.Integration.Tests
                 var userName = "developer1";
                 var password = "devp@ss01!";
 
-                IDoesBasicAuthentication fixture = FixtureHelper.CreateLdapCredentialValidator(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName);
+                IDoesBasicAuthentication fixture = FixtureHelper.CreateLdapCredentialValidator(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName, _testLogger);
 
                 // Act
                 var result = fixture.ValidateCredentials(userName, password, new CancellationToken());
@@ -44,7 +51,7 @@ namespace Ldap.Integration.Tests
                 var userName = "developer1";
                 var password = "developer_pass";
 
-                IDoesBasicAuthentication fixture = FixtureHelper.CreateLdapCredentialValidator(ConfigurationHelper.GetOpenLdapConfiguration(), userName);
+                IDoesBasicAuthentication fixture = FixtureHelper.CreateLdapCredentialValidator(ConfigurationHelper.GetOpenLdapConfiguration(), userName, _testLogger);
 
                 // Act
                 var result = fixture.ValidateCredentials(userName, password, new CancellationToken());

--- a/source/Ldap.Integration.Tests/IDoesBasicAuthenticationTests.cs
+++ b/source/Ldap.Integration.Tests/IDoesBasicAuthenticationTests.cs
@@ -45,6 +45,31 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
+            internal void ValidatesAUserFromActiveDirectoryWithSpecialCharacters()
+            {
+                // Arrange
+                var userName = "special#1";
+                var password = "devp@ss01!";
+
+                IDoesBasicAuthentication fixture = FixtureHelper.CreateLdapCredentialValidator(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName, _testLogger);
+
+                // Act
+                var result = fixture.ValidateCredentials(userName, password, new CancellationToken());
+
+                // Assert
+                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
+                var user = ((ResultFromExtension<IUser>)result).Value;
+
+                Assert.Equal("special#1@mycompany.local", user.Username);
+                Assert.Equal("Special User #1", user.DisplayName);
+                Assert.Equal("special#1@mycompany.local", user.EmailAddress);
+                Assert.Equal("special#1", user.Identities.First().Claims["uan"].Value);
+                Assert.Equal("special#1@mycompany.local", user.Identities.First().Claims["upn"].Value);
+                Assert.Equal("special#1@mycompany.local", user.Identities.First().Claims["email"].Value);
+                Assert.Equal("Special User #1", user.Identities.First().Claims["dn"].Value);
+            }
+
+            [Fact]
             internal void ValidatesAUserFromOpenLDAP()
             {
                 // Arrange

--- a/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
+++ b/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
@@ -113,9 +113,8 @@ namespace Ldap.Integration.Tests
                 
                 var expectedGroups = new[]
                 {
-                    "cn=SpecialGroup (with brackets),ou=Groups,dc=domain1,dc=local",
-                    "cn=SpecialGroup# with a hash,ou=Groups,dc=domain1,dc=local",
-                    "cn=SpecialGroup\\2C with a comma,ou=Groups,dc=domain1,dc=local",
+                    "cn=SpecialGroup Parent,ou=Groups,dc=domain1,dc=local",
+                    "cn=SpecialGroup \\2C \\5C # \\2B \\3C \\3E \\3B \\22 \\3D,ou=Groups,dc=domain1,dc=local",
                     "cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=domain1,dc=local"
                 };
 

--- a/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
+++ b/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
@@ -4,6 +4,7 @@ using Ldap.Integration.Tests.TestHelpers;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Results;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests
 {
@@ -11,6 +12,12 @@ namespace Ldap.Integration.Tests
     {
         public class TheReadMethod
         {
+            readonly ITestOutputHelper _testLogger;
+            public TheReadMethod(ITestOutputHelper testLogger)
+            {
+                _testLogger = testLogger;
+            }
+            
             [Fact]
             internal void ReadsGroupsForAUserFromActiveDirectory()
             {
@@ -24,7 +31,7 @@ namespace Ldap.Integration.Tests
                     "cn=Maintainers,ou=Groups,dc=mycompany,dc=local",
                 };
 
-                IExternalGroupRetriever fixture = FixtureHelper.CreateFixtureGroupRetriever(ConfigurationHelper.GetActiveDirectoryConfiguration());
+                IExternalGroupRetriever fixture = FixtureHelper.CreateFixtureGroupRetriever(ConfigurationHelper.GetActiveDirectoryConfiguration(), _testLogger);
 
                 // Act
                 var result = fixture.Read(user, new System.Threading.CancellationToken());
@@ -53,7 +60,7 @@ namespace Ldap.Integration.Tests
                     "cn=DeveloperGroup1,ou=Groups,dc=domain1,dc=local"
                 };
 
-                IExternalGroupRetriever fixture = FixtureHelper.CreateFixtureGroupRetriever(ConfigurationHelper.GetOpenLdapConfiguration());
+                IExternalGroupRetriever fixture = FixtureHelper.CreateFixtureGroupRetriever(ConfigurationHelper.GetOpenLdapConfiguration(), _testLogger);
 
                 // Act
                 var result = fixture.Read(user, new System.Threading.CancellationToken());

--- a/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
+++ b/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
@@ -55,9 +55,8 @@ namespace Ldap.Integration.Tests
 
                 var expectedGroups = new[]
                 {
-                    "cn=SpecialGroup (with brackets),ou=Groups,dc=mycompany,dc=local",
-                    "cn=SpecialGroup\\# with a hash,ou=Groups,dc=mycompany,dc=local",
-                    "cn=SpecialGroup\\, with a comma,ou=Groups,dc=mycompany,dc=local",
+                    "cn=SpecialGroup Parent,ou=Groups,dc=mycompany,dc=local",
+                    "cn=SpecialGroup \\, \\\\ \\# \\+ \\< \\> \\; \\\" \\=,ou=Groups,dc=mycompany,dc=local",
                     "cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=mycompany,dc=local"
                 };
 

--- a/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
+++ b/source/Ldap.Integration.Tests/IExternalGroupRetrieverTests.cs
@@ -82,6 +82,7 @@ namespace Ldap.Integration.Tests
                 // Arrange
                 var user = new FakeUser("developer1");
 
+                // Note that ActiveDirectory returns the reserved DN characters in escaped backslashformat, eg \, for , (comma)
                 var expectedGroups = new[]
                 {
                     "cn=Maintainers,ou=Groups,dc=domain1,dc=local",
@@ -111,6 +112,7 @@ namespace Ldap.Integration.Tests
                 // Arrange
                 var user = new FakeUser("special#1");
                 
+                // Note that openLdap returns the reserved DN characters in escaped hex format, eg \2C for , (comma) and strangely doesnt encode the pound (#) symbol
                 var expectedGroups = new[]
                 {
                     "cn=SpecialGroup Parent,ou=Groups,dc=domain1,dc=local",

--- a/source/Ldap.Integration.Tests/ISupportsAutoUserCreationFromPrincipalTests.cs
+++ b/source/Ldap.Integration.Tests/ISupportsAutoUserCreationFromPrincipalTests.cs
@@ -44,6 +44,30 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
+            internal void CreatesAUserFromActiveDirectoryWithSpecialCharacters()
+            {
+                // Arrange
+                var userName = "special#1";
+
+                ISupportsAutoUserCreationFromPrincipal fixture = FixtureHelper.CreateLdapUserCreationFromPrincipal(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName, _testLogger);
+
+                // Act
+                var result = fixture.GetOrCreateUser(new FakePrincipal(userName), new CancellationToken());
+
+                // Assert
+                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
+                var createdUser = ((ResultFromExtension<IUser>)result).Value;
+
+                Assert.Equal("special#1@mycompany.local", createdUser.Username);
+                Assert.Equal("Special User #1", createdUser.DisplayName);
+                Assert.Equal("special#1@mycompany.local", createdUser.EmailAddress);
+                Assert.Equal("special#1", createdUser.Identities.First().Claims["uan"].Value);
+                Assert.Equal("special#1@mycompany.local", createdUser.Identities.First().Claims["upn"].Value);
+                Assert.Equal("special#1@mycompany.local", createdUser.Identities.First().Claims["email"].Value);
+                Assert.Equal("Special User #1", createdUser.Identities.First().Claims["dn"].Value);
+            }
+
+            [Fact]
             internal void CreatesAUserFromOpenLDAP()
             {
                 // Arrange

--- a/source/Ldap.Integration.Tests/ISupportsAutoUserCreationFromPrincipalTests.cs
+++ b/source/Ldap.Integration.Tests/ISupportsAutoUserCreationFromPrincipalTests.cs
@@ -44,30 +44,6 @@ namespace Ldap.Integration.Tests
             }
 
             [Fact]
-            internal void CreatesAUserFromActiveDirectoryWithSpecialCharacters()
-            {
-                // Arrange
-                var userName = "special#1";
-
-                ISupportsAutoUserCreationFromPrincipal fixture = FixtureHelper.CreateLdapUserCreationFromPrincipal(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName, _testLogger);
-
-                // Act
-                var result = fixture.GetOrCreateUser(new FakePrincipal(userName), new CancellationToken());
-
-                // Assert
-                ExtensionResultHelper.AssertSuccesfulExtensionResult(result);
-                var createdUser = ((ResultFromExtension<IUser>)result).Value;
-
-                Assert.Equal("special#1@mycompany.local", createdUser.Username);
-                Assert.Equal("Special User #1", createdUser.DisplayName);
-                Assert.Equal("special#1@mycompany.local", createdUser.EmailAddress);
-                Assert.Equal("special#1", createdUser.Identities.First().Claims["uan"].Value);
-                Assert.Equal("special#1@mycompany.local", createdUser.Identities.First().Claims["upn"].Value);
-                Assert.Equal("special#1@mycompany.local", createdUser.Identities.First().Claims["email"].Value);
-                Assert.Equal("Special User #1", createdUser.Identities.First().Claims["dn"].Value);
-            }
-
-            [Fact]
             internal void CreatesAUserFromOpenLDAP()
             {
                 // Arrange

--- a/source/Ldap.Integration.Tests/ISupportsAutoUserCreationFromPrincipalTests.cs
+++ b/source/Ldap.Integration.Tests/ISupportsAutoUserCreationFromPrincipalTests.cs
@@ -5,6 +5,7 @@ using Octopus.Data.Model.User;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Results;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests
 {
@@ -12,13 +13,19 @@ namespace Ldap.Integration.Tests
     {
         public class TheGetOrCreateUserMethod
         {
+            readonly ITestOutputHelper _testLogger;
+            public TheGetOrCreateUserMethod(ITestOutputHelper testLogger)
+            {
+                _testLogger = testLogger;
+            }
+
             [Fact]
             internal void CreatesAUserFromActiveDirectory()
             {
                 // Arrange
                 var userName = "developer1";
 
-                ISupportsAutoUserCreationFromPrincipal fixture = FixtureHelper.CreateLdapUserCreationFromPrincipal(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName);
+                ISupportsAutoUserCreationFromPrincipal fixture = FixtureHelper.CreateLdapUserCreationFromPrincipal(ConfigurationHelper.GetActiveDirectoryConfiguration(), userName, _testLogger);
 
                 // Act
                 var result = fixture.GetOrCreateUser(new FakePrincipal(userName), new CancellationToken());
@@ -42,7 +49,7 @@ namespace Ldap.Integration.Tests
                 // Arrange
                 var userName = "developer1";
 
-                ISupportsAutoUserCreationFromPrincipal fixture = FixtureHelper.CreateLdapUserCreationFromPrincipal(ConfigurationHelper.GetOpenLdapConfiguration(), userName);
+                ISupportsAutoUserCreationFromPrincipal fixture = FixtureHelper.CreateLdapUserCreationFromPrincipal(ConfigurationHelper.GetOpenLdapConfiguration(), userName, _testLogger);
 
                 // Act
                 var result = fixture.GetOrCreateUser(new FakePrincipal(userName), new CancellationToken());

--- a/source/Ldap.Integration.Tests/TestHelpers/FixtureHelper.cs
+++ b/source/Ldap.Integration.Tests/TestHelpers/FixtureHelper.cs
@@ -4,29 +4,31 @@ using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Ldap;
 using Octopus.Server.Extensibility.Authentication.Ldap.Configuration;
 using Octopus.Server.Extensibility.Authentication.Ldap.Identities;
+using Xunit.Abstractions;
 
 namespace Ldap.Integration.Tests.TestHelpers
 {
     internal static class FixtureHelper
     {
-        public static UserMatcher CreateUserMatcher(LdapConfiguration configuration)
+        public static UserMatcher CreateUserMatcher(LdapConfiguration configuration, ITestOutputHelper testLogger)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
+            var log = new TestLogger(testLogger);
 
             return new UserMatcher(
-                new LdapContextProvider(new Lazy<ILdapConfigurationStore>(() => configurationStore), Substitute.For<ISystemLog>()),
+                new LdapContextProvider(new Lazy<ILdapConfigurationStore>(() => configurationStore), log),
                 new LdapObjectNameNormalizer(new Lazy<ILdapConfigurationStore>(() => configurationStore)),
                 configurationStore,
                 new UserPrincipalFinder(),
                 new IdentityCreator());
         }
 
-        public static LdapUserCreationFromPrincipal CreateLdapUserCreationFromPrincipal(LdapConfiguration configuration, string userStoreUserName)
+        public static LdapUserCreationFromPrincipal CreateLdapUserCreationFromPrincipal(LdapConfiguration configuration, string userStoreUserName, ITestOutputHelper testLogger)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
             var nameNormalizer = new LdapObjectNameNormalizer(new Lazy<ILdapConfigurationStore>(() => configurationStore));
 
-            var log = Substitute.For<ISystemLog>();
+            var log = new TestLogger(testLogger);
             var ldapService = new LdapService(
                 log,
                 nameNormalizer,
@@ -44,12 +46,12 @@ namespace Ldap.Integration.Tests.TestHelpers
             return new LdapUserCreationFromPrincipal(configurationStore, credentialValidator);
         }
 
-        public static LdapCredentialValidator CreateLdapCredentialValidator(LdapConfiguration configuration, string userStoreUserName)
+        public static LdapCredentialValidator CreateLdapCredentialValidator(LdapConfiguration configuration, string userStoreUserName, ITestOutputHelper testLogger)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
             var nameNormalizer = new LdapObjectNameNormalizer(new Lazy<ILdapConfigurationStore>(() => configurationStore));
 
-            var log = Substitute.For<ISystemLog>();
+            var log = new TestLogger(testLogger);
             var ldapService = new LdapService(
                 log,
                 nameNormalizer,
@@ -65,10 +67,10 @@ namespace Ldap.Integration.Tests.TestHelpers
                 ldapService);
         }
 
-        public static GroupRetriever CreateFixtureGroupRetriever(LdapConfiguration configuration)
+        public static GroupRetriever CreateFixtureGroupRetriever(LdapConfiguration configuration, ITestOutputHelper testLogger)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
-            var log = Substitute.For<ISystemLog>();
+            var log = new TestLogger(testLogger);
 
             var groupLocator = new LdapExternalSecurityGroupLocator(
                 log,
@@ -81,10 +83,10 @@ namespace Ldap.Integration.Tests.TestHelpers
             return new GroupRetriever(log, configurationStore, groupLocator);
         }
 
-        public static LdapExternalSecurityGroupLocator CreateLdapExternalSecurityGroupLocator(LdapConfiguration configuration)
+        public static LdapExternalSecurityGroupLocator CreateLdapExternalSecurityGroupLocator(LdapConfiguration configuration, ITestOutputHelper testLogger)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
-            var log = Substitute.For<ISystemLog>();
+            var log = new TestLogger(testLogger);
 
             return new LdapExternalSecurityGroupLocator(
                 log,
@@ -96,10 +98,10 @@ namespace Ldap.Integration.Tests.TestHelpers
                 );
         }
 
-        public static UserSearch CreateUserSearch(LdapConfiguration configuration)
+        public static UserSearch CreateUserSearch(LdapConfiguration configuration, ITestOutputHelper testLogger)
         {
             var configurationStore = new FakeLdapConfigurationStore(configuration);
-            var log = Substitute.For<ISystemLog>();
+            var log = new TestLogger(testLogger);
 
             return new UserSearch(
                 new LdapContextProvider(new Lazy<ILdapConfigurationStore>(() => configurationStore), log),

--- a/source/Ldap.Integration.Tests/TestHelpers/TestLogger.cs
+++ b/source/Ldap.Integration.Tests/TestHelpers/TestLogger.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Octopus.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Ldap.Integration.Tests.TestHelpers
+{
+    class TestLogger : ISystemLog
+    {
+        readonly ITestOutputHelper _testOutputHelper;
+
+        public string CorrelationId => throw new NotImplementedException();
+
+        public TestLogger(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public static string GetCaller([CallerMemberName] string caller = null)
+        {
+            return caller;
+        }
+
+        public ISystemLog ChildContext(string[] sensitiveValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void Error(string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void Error(Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {error}");
+        }
+
+        public void Error(Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText} {error}");
+        }
+
+        public void ErrorFormat(string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(messageFormat, args)}");
+        }
+
+        public void ErrorFormat(Exception error, string format, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(format, args)} {error}");
+        }
+
+        public void Fatal(string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void Fatal(Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {error}");
+        }
+
+        public void Fatal(Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText} {error}");
+        }
+
+        public void FatalFormat(string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(messageFormat, args)}");
+        }
+
+        public void FatalFormat(Exception error, string format, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(format, args)} {error}");
+        }
+
+        public void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Info(string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void Info(Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {error}");
+        }
+
+        public void Info(Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText} {error}");
+        }
+
+        public void InfoFormat(string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(messageFormat, args)}");
+        }
+
+        public void InfoFormat(Exception error, string format, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(format, args)} {error}");
+        }
+
+        public void Trace(string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void Trace(Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {error}");
+        }
+
+        public void Trace(Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void TraceFormat(string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(messageFormat, args)}");
+        }
+
+        public void TraceFormat(Exception error, string format, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(format, args)} {error}");
+        }
+
+        public void Verbose(string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void Verbose(Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {error}");
+        }
+
+        public void Verbose(Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void VerboseFormat(string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(messageFormat, args)}");
+        }
+
+        public void VerboseFormat(Exception error, string format, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(format, args)} {error}");
+        }
+
+        public void Warn(string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void Warn(Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {error}");
+        }
+
+        public void Warn(Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {messageText}");
+        }
+
+        public void WarnFormat(string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(messageFormat, args)}");
+        }
+
+        public void WarnFormat(Exception error, string format, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {string.Format(format, args)} {error}");
+        }
+
+        public void WithSensitiveValue(string sensitiveValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WithSensitiveValues(string[] sensitiveValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write(LogCategory category, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {category} {messageText}");
+        }
+
+        public void Write(LogCategory category, Exception error)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {category} {error}");
+        }
+
+        public void Write(LogCategory category, Exception error, string messageText)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {category} {messageText} {error}");
+        }
+
+        public void WriteFormat(LogCategory category, string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {category} {string.Format(messageFormat, args)}");
+        }
+
+        public void WriteFormat(LogCategory category, Exception error, string messageFormat, params object[] args)
+        {
+            _testOutputHelper.WriteLine($"{GetCaller()}: {category} {string.Format(messageFormat,args)} {error}");
+        }
+    }
+}

--- a/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Remove-ActiveDirectoryIntegrationTestData.ps1
+++ b/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Remove-ActiveDirectoryIntegrationTestData.ps1
@@ -7,3 +7,10 @@ Get-ADGroup "DeveloperGroup2" | Remove-ADGroup -Confirm:$false
 
 Get-ADUser "developer1" | Remove-ADUser -Confirm:$false
 Get-ADUser "developer2" | Remove-ADUser -Confirm:$false
+
+Get-ADGroup "SpecialGroup (with brackets)" | Remove-ADGroup -Confirm:$false
+Get-ADGroup "SpecialGroup# with a hash" | Remove-ADGroup -Confirm:$false
+Get-ADGroup "SpecialGroup_ with a comma" | Remove-ADGroup -Confirm:$false
+Get-ADGroup "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" | Remove-ADGroup -Confirm:$false
+
+Get-ADUser "special#1" | Remove-ADUser -Confirm:$false

--- a/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Remove-ActiveDirectoryIntegrationTestData.ps1
+++ b/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Remove-ActiveDirectoryIntegrationTestData.ps1
@@ -8,9 +8,8 @@ Get-ADGroup "DeveloperGroup2" | Remove-ADGroup -Confirm:$false
 Get-ADUser "developer1" | Remove-ADUser -Confirm:$false
 Get-ADUser "developer2" | Remove-ADUser -Confirm:$false
 
-Get-ADGroup "SpecialGroup (with brackets)" | Remove-ADGroup -Confirm:$false
-Get-ADGroup "SpecialGroup# with a hash" | Remove-ADGroup -Confirm:$false
-Get-ADGroup "SpecialGroup_ with a comma" | Remove-ADGroup -Confirm:$false
+Get-ADGroup "SpecialGroup Parent" | Remove-ADGroup -Confirm:$false
+Get-ADGroup "SpecialGroup _ _ # _ _ _ _ _ _" | Remove-ADGroup -Confirm:$false
 Get-ADGroup "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" | Remove-ADGroup -Confirm:$false
 
 Get-ADUser "special#1" | Remove-ADUser -Confirm:$false

--- a/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Update-ActiveDirectoryIntegrationTestData.ps1
+++ b/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Update-ActiveDirectoryIntegrationTestData.ps1
@@ -18,15 +18,13 @@ Get-ADGroup "Developers" | Add-ADGroupMember -Members @(Get-ADGroup "DeveloperGr
 Get-ADGroup "DeveloperGroup1" | Add-ADGroupMember -Members @(Get-ADUser "developer1")
 Get-ADGroup "DeveloperGroup2" | Add-ADGroupMember -Members @(Get-ADUser "developer2")
 
-New-ADGroup "SpecialGroup (with brackets)" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
-New-ADGroup "SpecialGroup# with a hash" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
-New-ADGroup "SpecialGroup, with a comma" -SamAccountName "SpecialGroup_ with a comma" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
+New-ADGroup "SpecialGroup Parent" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
+New-ADGroup 'SpecialGroup , \ # + < > ; " =' -SamAccountName "SpecialGroup _ _ # _ _ _ _ _ _" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
 New-ADGroup "SpecialGroup * ( ) . & - _ [ ] `` ~ | @ $ % ^ ? : { } ! '" -SamAccountName "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
 
-$specialPass = ConvertTo-SecureString -AsPlainText "specialp@ss01!" -Force
+$specialPass = ConvertTo-SecureString -AsPlainText "specp@ss01!" -Force
 New-ADUser -Name "special#1" -Enabled:$true -GivenName "Special" -Surname "#1" -SamAccountName "special#1" -UserPrincipalName "special#1@mycompany.local" -AccountPassword $specialPass -EmailAddress "special#1@mycompany.local" -DisplayName "Special User #1"
 
-Get-ADGroup "SpecialGroup (with brackets)" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
-Get-ADGroup "SpecialGroup# with a hash" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
-Get-ADGroup "SpecialGroup_ with a comma" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
+Get-ADGroup "SpecialGroup Parent" | Add-ADGroupMember -Members @(Get-ADGroup "SpecialGroup _ _ # _ _ _ _ _ _")
+Get-ADGroup "SpecialGroup _ _ # _ _ _ _ _ _" | Add-ADGroupMember -Members @(Get-ADGroup "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '")
 Get-ADGroup "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")

--- a/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Update-ActiveDirectoryIntegrationTestData.ps1
+++ b/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Update-ActiveDirectoryIntegrationTestData.ps1
@@ -23,7 +23,8 @@ New-ADGroup "SpecialGroup# with a hash" -Path "OU=Groups,DC=mycompany,DC=local" 
 New-ADGroup "SpecialGroup, with a comma" -SamAccountName "SpecialGroup_ with a comma" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
 New-ADGroup "SpecialGroup * ( ) . & - _ [ ] `` ~ | @ $ % ^ ? : { } ! '" -SamAccountName "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
 
-New-ADUser -Name "special#1" -Enabled:$true -GivenName "Special" -Surname "#1" -SamAccountName "special#1" -UserPrincipalName "special#1@mycompany.local" -AccountPassword $devPass -EmailAddress "special#1@mycompany.local" -DisplayName "Special User #1"
+$specialPass = ConvertTo-SecureString -AsPlainText "specialp@ss01!" -Force
+New-ADUser -Name "special#1" -Enabled:$true -GivenName "Special" -Surname "#1" -SamAccountName "special#1" -UserPrincipalName "special#1@mycompany.local" -AccountPassword $specialPass -EmailAddress "special#1@mycompany.local" -DisplayName "Special User #1"
 
 Get-ADGroup "SpecialGroup (with brackets)" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
 Get-ADGroup "SpecialGroup# with a hash" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")

--- a/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Update-ActiveDirectoryIntegrationTestData.ps1
+++ b/source/Ldap.Integration.Tests/scripts/ActiveDirectory/Update-ActiveDirectoryIntegrationTestData.ps1
@@ -1,5 +1,7 @@
 Import-Module ActiveDirectory
 
+New-ADOrganizationalUnit "Groups"
+
 New-ADGroup "Maintainers" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
 New-ADGroup "Developers" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
 New-ADGroup "DeveloperGroup1" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
@@ -15,3 +17,15 @@ Get-ADGroup "Developers" | Add-ADGroupMember -Members @(Get-ADGroup "DeveloperGr
 
 Get-ADGroup "DeveloperGroup1" | Add-ADGroupMember -Members @(Get-ADUser "developer1")
 Get-ADGroup "DeveloperGroup2" | Add-ADGroupMember -Members @(Get-ADUser "developer2")
+
+New-ADGroup "SpecialGroup (with brackets)" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
+New-ADGroup "SpecialGroup# with a hash" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
+New-ADGroup "SpecialGroup, with a comma" -SamAccountName "SpecialGroup_ with a comma" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
+New-ADGroup "SpecialGroup * ( ) . & - _ [ ] `` ~ | @ $ % ^ ? : { } ! '" -SamAccountName "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" -Path "OU=Groups,DC=mycompany,DC=local" -GroupCategory Security -GroupScope Global
+
+New-ADUser -Name "special#1" -Enabled:$true -GivenName "Special" -Surname "#1" -SamAccountName "special#1" -UserPrincipalName "special#1@mycompany.local" -AccountPassword $devPass -EmailAddress "special#1@mycompany.local" -DisplayName "Special User #1"
+
+Get-ADGroup "SpecialGroup (with brackets)" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
+Get-ADGroup "SpecialGroup# with a hash" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
+Get-ADGroup "SpecialGroup_ with a comma" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")
+Get-ADGroup "SpecialGroup _ ( ) . & - _ _ _ ` ~ _ @ $ % ^ _ _ { } ! '" | Add-ADGroupMember  -Members @(Get-ADUser "special#1")

--- a/source/Ldap.Integration.Tests/scripts/OpenLdap/bootstrap.ldif
+++ b/source/Ldap.Integration.Tests/scripts/OpenLdap/bootstrap.ldif
@@ -69,26 +69,20 @@ displayname: Special User 1
 mail: special#1@gmail.com
 userpassword: special_pass
 
-dn: cn=SpecialGroup (with brackets),ou=Groups,dc=domain1,dc=local
-changetype: add
-cn: SpecialGroup (with brackets)
-objectclass: groupOfUniqueNames
-uniqueMember: cn=special\#1,dc=domain1,dc=local
-
-dn: cn=SpecialGroup\# with a hash,ou=Groups,dc=domain1,dc=local
-changetype: add
-cn: SpecialGroup# with a hash
-objectclass: groupOfUniqueNames
-uniqueMember: cn=special\#1,dc=domain1,dc=local
-
-dn: cn=SpecialGroup\, with a comma,ou=Groups,dc=domain1,dc=local
-changetype: add
-cn: SpecialGroup, with a comma
-objectclass: groupOfUniqueNames
-uniqueMember: cn=special\#1,dc=domain1,dc=local
-
 dn: cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=domain1,dc=local
 changetype: add
 cn: SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '
 objectclass: groupOfUniqueNames
 uniqueMember: cn=special\#1,dc=domain1,dc=local
+
+dn: cn=SpecialGroup \, \\ \# \+ \< \> \; \" \=,ou=Groups,dc=domain1,dc=local
+changetype: add
+cn: SpecialGroup \, \\ \# \+ \< \> \; \" \=,ou=Groups,dc=domain1,dc=local
+objectclass: groupOfUniqueNames
+uniqueMember: cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=domain1,dc=local
+
+dn: cn=SpecialGroup Parent,ou=Groups,dc=domain1,dc=local
+changetype: add
+cn: SpecialGroup Parent
+objectclass: groupOfUniqueNames
+uniqueMember: cn=SpecialGroup \, \\ \# \+ \< \> \; \" \=,ou=Groups,dc=domain1,dc=local

--- a/source/Ldap.Integration.Tests/scripts/OpenLdap/bootstrap.ldif
+++ b/source/Ldap.Integration.Tests/scripts/OpenLdap/bootstrap.ldif
@@ -58,3 +58,37 @@ changetype: add
 cn: Maintainers
 objectclass: groupOfUniqueNames
 uniqueMember: cn=Developers,ou=Groups,dc=domain1,dc=local
+
+dn: cn=special\#1,dc=domain1,dc=local
+changetype: add
+objectclass: inetOrgPerson
+cn: special#1
+givenname: Special
+sn: #1
+displayname: Special User 1
+mail: special#1@gmail.com
+userpassword: special_pass
+
+dn: cn=SpecialGroup (with brackets),ou=Groups,dc=domain1,dc=local
+changetype: add
+cn: SpecialGroup (with brackets)
+objectclass: groupOfUniqueNames
+uniqueMember: cn=special\#1,dc=domain1,dc=local
+
+dn: cn=SpecialGroup\# with a hash,ou=Groups,dc=domain1,dc=local
+changetype: add
+cn: SpecialGroup# with a hash
+objectclass: groupOfUniqueNames
+uniqueMember: cn=special\#1,dc=domain1,dc=local
+
+dn: cn=SpecialGroup\, with a comma,ou=Groups,dc=domain1,dc=local
+changetype: add
+cn: SpecialGroup, with a comma
+objectclass: groupOfUniqueNames
+uniqueMember: cn=special\#1,dc=domain1,dc=local
+
+dn: cn=SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ',ou=Groups,dc=domain1,dc=local
+changetype: add
+cn: SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '
+objectclass: groupOfUniqueNames
+uniqueMember: cn=special\#1,dc=domain1,dc=local

--- a/source/Ldap.Tests/NestedGroupFinderTests.cs
+++ b/source/Ldap.Tests/NestedGroupFinderTests.cs
@@ -15,7 +15,7 @@ namespace Ldap.Tests
         internal void FindAllParentGroupsTest(NestedGroupTestDataSource testData)
         {
             var parentFinder = new ParentFinder(testData.Groups);
-            var context = Substitute.For<LdapContext>();
+            var context = Substitute.For<LdapContext>(null, null);
             var nestedFinder = new NestedGroupFinder(parentFinder);
             var results = nestedFinder.FindAllParentGroups(context, testData.SearchDepth, testData.InitialGroups);
 

--- a/source/Server/Ldap/GroupParentFinder.cs
+++ b/source/Server/Ldap/GroupParentFinder.cs
@@ -20,7 +20,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             var result = context.LdapConnection.Search(
                 context.GroupBaseDN,
                 LdapConnection.ScopeSub,
-                context.NestedGroupFilter.Replace("*", name.ToString()),
+                context.NestedGroupFilter.Replace("*", name.ToString().EscapeForLdapSearchFilter()),
                 attributesToRetrieve,
                 false
             );

--- a/source/Server/Ldap/GroupParentFinder.cs
+++ b/source/Server/Ldap/GroupParentFinder.cs
@@ -13,17 +13,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
     public class GroupParentFinder : IGroupParentFinder
     {
-        public IEnumerable<GroupDistinguishedName> FindParentGroups(LdapContext context, GroupDistinguishedName name)
+        public IEnumerable<GroupDistinguishedName> FindParentGroups(LdapContext context, GroupDistinguishedName groupDistinguishedName)
         {
-            var attributesToRetrieve = new[] {"cn", "dn" };
-
-            var result = context.LdapConnection.Search(
-                context.GroupBaseDN,
-                LdapConnection.ScopeSub,
-                context.NestedGroupFilter.Replace("*", name.ToString().EscapeForLdapSearchFilter()),
-                attributesToRetrieve,
-                false
-            );
+            var result = context.SearchParentGroups(groupDistinguishedName);
 
             return result.Select(r => r.Dn).ToGroupDistinguishedNames();
         }

--- a/source/Server/Ldap/LdapContext.cs
+++ b/source/Server/Ldap/LdapContext.cs
@@ -42,7 +42,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         internal ILdapSearchResults SearchUsers(string searchToken)
         {
-            var escapedValue = $"*{searchToken.EscapeForLdapSearchFilter()}*";
+            var escapedValue = $"*{searchToken.EscapeForLdapSearchFilter(log)}*";
             var searchFilter = UserFilter?.Replace("*", escapedValue);
 
             var results = SearchLdap(
@@ -64,7 +64,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         internal LdapEntry FindUser(string userName)
         {
-            var escapedValue = userName.EscapeForLdapSearchFilter();
+            var escapedValue = userName.EscapeForLdapSearchFilter(log);
             var searchFilter = UserFilter?.Replace("*", escapedValue);
 
             var results = SearchLdap(
@@ -86,7 +86,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         internal List<LdapEntry> SearchGroups(string searchToken)
         {
-            var escapedValue = $"*{searchToken.EscapeForLdapSearchFilter()}*";
+            var escapedValue = $"*{searchToken.EscapeForLdapSearchFilter(log)}*";
             var searchFilter = GroupFilter.Replace("*", escapedValue);
 
             var results = SearchLdap(
@@ -104,7 +104,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         internal List<LdapEntry> SearchParentGroups(GroupDistinguishedName groupDistinguishedName)
         {
-            var escapedValue = groupDistinguishedName.ToString().EscapeForLdapSearchFilter();
+            var escapedValue = groupDistinguishedName.ToString().EscapeForLdapSearchFilter(log);
             var searchFilter = NestedGroupFilter.Replace("*", escapedValue);
 
             var results = SearchLdap(
@@ -122,7 +122,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         private ILdapSearchResults SearchLdap(string searchBase, string escapedearchFilter, string[] attributes)
         {
-            log.Verbose($"LDAP::Search (Base: '{searchBase}' Filter: '{escapedearchFilter}' Attributes: '{string.Join(",", attributes)}')");
+            log.Verbose($"LDAP::SearchLdap (Base: '{searchBase}' Filter: '{escapedearchFilter}' Attributes: '{string.Join(",", attributes)}')");
             return ldapConnection.Search(
                 searchBase,
                 LdapConnection.ScopeSub,

--- a/source/Server/Ldap/LdapContext.cs
+++ b/source/Server/Ldap/LdapContext.cs
@@ -1,11 +1,22 @@
 ﻿using Novell.Directory.Ldap;
+using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.Authentication.Ldap.Model;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapContext : IDisposable
     {
-        public LdapConnection LdapConnection { get; internal set; }
+        readonly LdapConnection ldapConnection;
+        readonly ISystemLog log;
+
+        public LdapContext(LdapConnection ldapConnection, ISystemLog log)
+        {
+            this.ldapConnection = ldapConnection;
+            this.log = log;
+        }
 
         public string UserBaseDN { get; internal set; }
 
@@ -29,12 +40,109 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public string GroupNameAttribute { get; internal set; }
 
+        internal ILdapSearchResults SearchUsers(string searchToken)
+        {
+            var escapedValue = $"*{searchToken.EscapeForLdapSearchFilter()}*";
+            var searchFilter = UserFilter?.Replace("*", escapedValue);
+
+            var results = SearchLdap(
+                UserBaseDN,
+                searchFilter,
+                new[]
+                {
+                    "cn",
+                    UserDisplayNameAttribute,
+                    UserMembershipAttribute,
+                    UserPrincipalNameAttribute,
+                    UserEmailAttribute,
+                    UniqueAccountNameAttribute
+                }
+            );
+
+            return results;
+        }
+
+        internal LdapEntry FindUser(string userName)
+        {
+            var escapedValue = userName.EscapeForLdapSearchFilter();
+            var searchFilter = UserFilter?.Replace("*", escapedValue);
+
+            var results = SearchLdap(
+                UserBaseDN,
+                searchFilter,
+                new[]
+                {
+                    "cn",
+                    UserDisplayNameAttribute,
+                    UserMembershipAttribute,
+                    UserPrincipalNameAttribute,
+                    UserEmailAttribute,
+                    UniqueAccountNameAttribute
+                }
+            );
+
+            return results?.FirstOrDefault();
+        }
+
+        internal List<LdapEntry> SearchGroups(string searchToken)
+        {
+            var escapedValue = $"*{searchToken.EscapeForLdapSearchFilter()}*";
+            var searchFilter = GroupFilter.Replace("*", escapedValue);
+
+            var results = SearchLdap(
+                GroupBaseDN,
+                searchFilter,
+                new[]
+                {
+                    "dn",
+                    GroupNameAttribute
+                }
+            );
+
+            return results.ToList();
+        }
+
+        internal List<LdapEntry> SearchParentGroups(GroupDistinguishedName groupDistinguishedName)
+        {
+            var escapedValue = groupDistinguishedName.ToString().EscapeForLdapSearchFilter();
+            var searchFilter = NestedGroupFilter.Replace("*", escapedValue);
+
+            var results = SearchLdap(
+                GroupBaseDN,
+                searchFilter,
+                new[]
+                {
+                    "dn",
+                    GroupNameAttribute
+                }
+            );
+
+            return results.ToList();
+        }
+
+        private ILdapSearchResults SearchLdap(string searchBase, string escapedearchFilter, string[] attributes)
+        {
+            log.Verbose($"LDAP::Search (Base: '{searchBase}' Filter: '{escapedearchFilter}' Attributes: '{string.Join(",", attributes)}')");
+            return ldapConnection.Search(
+                searchBase,
+                LdapConnection.ScopeSub,
+                escapedearchFilter,
+                attributes,
+                false);
+        }
+
+        public void ValidateCredentials(string distinguishedName, string password)
+        {
+            log.Verbose($"Calling LDAP::Bind ('{distinguishedName}')");
+            ldapConnection.Bind(distinguishedName, password);
+        }
+
         public void Dispose()
         {
-            if(LdapConnection?.Tls == true)
-                LdapConnection.StopTls();
+            if(ldapConnection?.Tls == true)
+                ldapConnection.StopTls();
             
-            LdapConnection?.Dispose();
+            ldapConnection?.Dispose();
         }
     }
 }

--- a/source/Server/Ldap/LdapContextProvider.cs
+++ b/source/Server/Ldap/LdapContextProvider.cs
@@ -50,9 +50,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
                     null,
                     ldapConfiguration.Value.GetReferralHopLimit());
 
-                return new LdapContext
+                return new LdapContext(con, log)
                 {
-                    LdapConnection = con,
                     UserBaseDN = ldapConfiguration.Value.GetUserBaseDn(),
                     GroupBaseDN = ldapConfiguration.Value.GetGroupBaseDn(),
                     UniqueAccountNameAttribute = ldapConfiguration.Value.GetUniqueAccountNameAttribute(),

--- a/source/Server/Ldap/LdapCredentialValidator.cs
+++ b/source/Server/Ldap/LdapCredentialValidator.cs
@@ -45,8 +45,6 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public IResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
         {
-            log.Verbose($"Validating credentials provided for '{username}'...");
-
             return GetOrCreateCommon(username, cancellationToken, () => ldapService.ValidateCredentials(username, password, cancellationToken));
         }
 

--- a/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
+++ b/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
@@ -57,7 +57,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             string partialGroupName;
             objectNameNormalizer.NormalizeName(name, out partialGroupName, out domain);
             using var context = contextProvider.GetContext();
-            var filterToken = $"*{partialGroupName}*";
+            var filterToken = $"*{partialGroupName.EscapeForLdapSearchFilter()}*";
             var lsc = context.LdapConnection.Search(
                 context.GroupBaseDN,
                 LdapConnection.ScopeSub,

--- a/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
+++ b/source/Server/Ldap/LdapExternalSecurityGroupLocator.cs
@@ -52,25 +52,15 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public ExternalSecurityGroup[] FindGroups(string name, CancellationToken cancellationToken)
         {
-            var results = new List<ExternalSecurityGroup>();
-            string domain;
-            string partialGroupName;
-            objectNameNormalizer.NormalizeName(name, out partialGroupName, out domain);
+            objectNameNormalizer.NormalizeName(name, out var partialGroupName, out var _);
+
             using var context = contextProvider.GetContext();
-            var filterToken = $"*{partialGroupName.EscapeForLdapSearchFilter()}*";
-            var lsc = context.LdapConnection.Search(
-                context.GroupBaseDN,
-                LdapConnection.ScopeSub,
-                context.GroupFilter?.Replace("*", filterToken),
-                new[] { context.GroupNameAttribute },
-                false
-            );
-            var searchResults = lsc.ToList();
-            results.AddRange(searchResults.Select(x => new ExternalSecurityGroup
+            var searchResults = context.SearchGroups(partialGroupName);
+            var results = searchResults.Select(x => new ExternalSecurityGroup
             {
                 Id = x.Dn,
                 DisplayName = x.GetAttribute(context.GroupNameAttribute).StringValue
-            }));
+            });
 
             return results.OrderBy(o => o.DisplayName).ToArray();
         }

--- a/source/Server/Ldap/LdapFilter.cs
+++ b/source/Server/Ldap/LdapFilter.cs
@@ -1,19 +1,26 @@
-﻿namespace Octopus.Server.Extensibility.Authentication.Ldap
+﻿using Octopus.Diagnostics;
+
+namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     static class LdapFilter
     {
-        public static string EscapeForLdapSearchFilter(this string value)
+        public static string EscapeForLdapSearchFilter(this string value, ISystemLog log)
         {
             // The library we are using already escapes DN characters but some special characters for Ldap search filters must be escaped,
             // Including the backslash character in the escaped DNs
             //
             // See: http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx#Special_Characters
-            return value
+            var escaped = value
                 .Replace("\\", "\\5C")
                 .Replace("*", "\\2A")
                 .Replace("(", "\\28")
                 .Replace(")", "\\29")
                 .Replace("\000", "\\00");
+
+            if (value != escaped)
+                log.Verbose($"LDAP::EscapeForLdapSearchFilter escaping '{value}' with '{escaped}'");
+
+            return escaped;
         }
     }
 }

--- a/source/Server/Ldap/LdapFilter.cs
+++ b/source/Server/Ldap/LdapFilter.cs
@@ -18,7 +18,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
                 .Replace("\000", "\\00");
 
             if (value != escaped)
-                log.Verbose($"LDAP::EscapeForLdapSearchFilter escaping '{value}' with '{escaped}'");
+                log.Verbose($"LDAP::EscapeFilter escaping '{value}' with '{escaped}'");
 
             return escaped;
         }

--- a/source/Server/Ldap/LdapFilter.cs
+++ b/source/Server/Ldap/LdapFilter.cs
@@ -1,17 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Octopus.Server.Extensibility.Authentication.Ldap
+﻿namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     static class LdapFilter
     {
         public static string EscapeForLdapSearchFilter(this string value)
         {
+            // The library we are using already escapes DN characters but some special characters for Ldap search filters must be escaped,
+            // Including the backslash character in the escaped DNs
+            //
+            // See: http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx#Special_Characters
             return value
-                .Replace("\\", "\\5C");
+                .Replace("\\", "\\5C")
+                .Replace("*", "\\2A")
+                .Replace("(", "\\28")
+                .Replace(")", "\\29")
+                .Replace("\000", "\\00");
         }
     }
 }

--- a/source/Server/Ldap/LdapFilter.cs
+++ b/source/Server/Ldap/LdapFilter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octopus.Server.Extensibility.Authentication.Ldap
+{
+    static class LdapFilter
+    {
+        public static string EscapeForLdapSearchFilter(this string value)
+        {
+            return value
+                .Replace("\\", "\\5C");
+        }
+    }
+}

--- a/source/Server/Ldap/LdapService.cs
+++ b/source/Server/Ldap/LdapService.cs
@@ -44,8 +44,7 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
             try
             {
-                log.Verbose($"Calling Bind ('{principal.DistinguishedName}')");
-                context.LdapConnection.Bind(principal.DistinguishedName, password);
+                context.ValidateCredentials(principal.DistinguishedName, password);
                 log.Verbose($"Credentials for '{uniqueAccountName}' validated, mapped to principal '{principal.UniqueAccountName}'");
             }
             catch (Exception)

--- a/source/Server/Ldap/UserPrincipalFinder.cs
+++ b/source/Server/Ldap/UserPrincipalFinder.cs
@@ -16,22 +16,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     {
         public UserPrincipal FindByIdentity(LdapContext context, string uniqueAccountName)
         {
-            var lsc = context.LdapConnection.Search(
-                context.UserBaseDN,
-                LdapConnection.ScopeSub,
-                context.UserFilter?.Replace("*", uniqueAccountName.EscapeForLdapSearchFilter()),
-                new[]
-                {
-                    "cn",
-                    context.UserDisplayNameAttribute,
-                    context.UserMembershipAttribute,
-                    context.UserPrincipalNameAttribute,
-                    context.UserEmailAttribute,
-                    context.UniqueAccountNameAttribute
-                },
-                false
-                );
-            var searchResult = lsc.FirstOrDefault();
+            var searchResult = context.FindUser(uniqueAccountName);
+
             if (searchResult == null)
                 return null;
 
@@ -53,23 +39,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 
         public IEnumerable<UserPrincipal> SearchUser(LdapContext context, string searchToken)
         {
-            var searchTerm = $"*{searchToken.EscapeForLdapSearchFilter()}*";
-            var lsc = context.LdapConnection.Search(
-                context.UserBaseDN,
-                LdapConnection.ScopeSub,
-                context.UserFilter?.Replace("*", searchTerm),
-                new[]
-                {
-                    "cn",
-                    context.UserDisplayNameAttribute,
-                    context.UserMembershipAttribute,
-                    context.UserPrincipalNameAttribute,
-                    context.UserEmailAttribute,
-                    context.UniqueAccountNameAttribute
-                },
-                false
-                );
-            return lsc.Select(x => CreatePrincipalFromLdapEntry(x, context)).ToList();
+            var results = context.SearchUsers(searchToken);
+
+            return results.Select(x => CreatePrincipalFromLdapEntry(x, context)).ToList();
         }
     }
 }

--- a/source/Server/Ldap/UserPrincipalFinder.cs
+++ b/source/Server/Ldap/UserPrincipalFinder.cs
@@ -16,11 +16,10 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
     {
         public UserPrincipal FindByIdentity(LdapContext context, string uniqueAccountName)
         {
-            var escapedName = ToLdapUniqueAccountName(uniqueAccountName);
             var lsc = context.LdapConnection.Search(
                 context.UserBaseDN,
                 LdapConnection.ScopeSub,
-                context.UserFilter?.Replace("*", escapedName),
+                context.UserFilter?.Replace("*", uniqueAccountName.EscapeForLdapSearchFilter()),
                 new[]
                 {
                     "cn",
@@ -52,18 +51,9 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
             };
         }
 
-        /// <summary>
-        /// Escapes uniqueAccountName for ldap queries.
-        /// </summary>
-        private string ToLdapUniqueAccountName(string uniqueAccountName)
-        {
-            // \e is simple backslash \ in LDAP, convert to recognized delimiter.
-            return uniqueAccountName.Replace("\\", "\\5C");
-        }
-
         public IEnumerable<UserPrincipal> SearchUser(LdapContext context, string searchToken)
         {
-            var searchTerm = $"*{ToLdapUniqueAccountName(searchToken)}*";
+            var searchTerm = $"*{searchToken.EscapeForLdapSearchFilter()}*";
             var lsc = context.LdapConnection.Search(
                 context.UserBaseDN,
                 LdapConnection.ScopeSub,


### PR DESCRIPTION
Fixes #49 

### Changes

* refactored the calls to the LDAP library to go through the `LdapContext` class, providing a central place to handle common concerns more easily
* handle the already escaped reserved DN characters when a DN is used in Ldap search filters
* handle escaping of special characters in ldap search filters
* add verbose logging of Ldap queries and character escaping to enable easier debugging in future
* updated the integration test data sets and added tests for both ActiveDirectory and OpenLdap to include example groups with all the known special characters in their name

### Testing Notes

We create a heirarchical group structure consisting of a parent group, wiith child group (containing special DN characters) containing a further child group (containing special LDAP Filter characters as well as some others that are technically allowed but seem nice to include for completeness sake to make sure we handle them!) and finally a test user.

When we load groups for this test user, walkking up the parent group hierarchy we confirm that we succesfully load all 3 groups, proving not only that we no longer get Ldap errors around search filter syntax (as per the logged issue) but also that the queries/escaping actually worked correctly and we did infact issue the query "which group contains this group DN as a member"

```
Special Group Parent
|
|-- SpecialGroup , \ # + < > ; " =
    |
    |-- SpecialGroup * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '
        |
        |-- special user
```

As seen in the wild in:

**ActiveDirectory**
![image](https://user-images.githubusercontent.com/5425163/141217537-5cb2e960-b23a-41ca-babb-744ec2d8ef71.png)

**OpenLdap**
![image](https://user-images.githubusercontent.com/5425163/141217478-986422f3-2bab-4276-be45-5a3f194ddead.png)

Happy days 🤣 
![image](https://user-images.githubusercontent.com/5425163/141218514-ce87fb36-7d10-46cb-a0e2-4abd0d9cb4ff.png)

### Out of Scope
When researching Ldap character esaping, some mentions were found relating to needing to escape spaces but only when leading or trailing.  Similary there was reference to unprintable unicode characters as being able to be escaped.

Until we encounter an actual scenario where a customer has groups containing trailing/leading spaces or unprintable unicode characters, we dont want to increase complexity by attempting to escape for these...  

Note that we have already seen cyrillic/russian characters in the wild already, which worked fine, so it isnt believed to impact "normal" non english characters which we do expect many customers will be using.

### More Context
There are 2 sets of special/reserved characters in LDAP, and there are also provider specific nuances as well 🙄 

A [few characters](http://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx#Special_Characters) need to be escaped when used in Ldap filters.  Namely these are `*` `(` `)` `\` and `NUL`

These need to be escaped with a backslash and converting the character into a 2 digit hex code.  For example `(` can be escaped as `\29` and `\` itself as `\5C`

Meanwhile, [another set](https://ldapwiki.com/wiki/DN%20Escape%20Values) of characters must be escaped when used in DNs and a further list of special characters are documented as not requiring escaping (we include them in our tests anyway just to be sure!).  When escaping DN characters, they can be escaped either with the same above backslash + hexcode method OR they can simply be escaped with a backslash only.  For example `<` can be either ``\<` or `\3C`.
The ldap library we use actually handles this DN escaping (and different providers seem to provide either of the 2 escape formats) so we don't need to do any specific escaping ourself for these... However as a backslash is used to escape them, and a bacckslash IS is a reserved ldap filter character, we DO need to escape the backslash when using that DN in a search filter query.  That is essentially the nature of this bug 🤣 

We observed a difference in AD vs OpenLDAP in the returned escaped DN values using either of the 2 acceptable formats. 
 For example in AD a chevron is returnedby the library as `\<` but in OpenLdap it is returned as `\3C`.  This doesnt strictly matter to our auth plugin, though our integration tests do need to use these variants as the "expected" value to asset on.  Since we don't attempt to unescape any values in this plugin, it does mean these strings would be passed to Octopus and used in the mapped identities for a Team bound to dap group or a user's Ldap group memberships.  As long as the values line up (which they do) it shouldn't pose a functional issue, though it will be displayed in the identity mappings.  