### PR TITLE
Remove querystring from api paths

### DIFF
--- a/source/Server/LdapApi.cs
+++ b/source/Server/LdapApi.cs
@@ -6,8 +6,8 @@ namespace Octopus.Server.Extensibility.Authentication.Ldap
 {
     public class LdapApi : RegistersEndpoints
     {
-        public const string ApiExternalGroupsSearch = "/api/externalgroups/ldap{?partialName}";
-        public const string ApiExternalUsersSearch = "/api/externalusers/ldap{?partialName}";
+        public const string ApiExternalGroupsSearch = "/api/externalgroups/ldap";
+        public const string ApiExternalUsersSearch = "/api/externalusers/ldap";
 
         public LdapApi()
         {


### PR DESCRIPTION
This is breaking one of our convention tests in `SwaggerFixture`. This _shouldn't_ have any functional change - the `Path` isn't used anywhere in the provider itself.
## Before
![image](https://user-images.githubusercontent.com/11970672/157166601-4402b97c-1499-4b71-821a-00592064b843.png)

## After
![image](https://user-images.githubusercontent.com/11970672/157166185-2b0c9a59-e24e-40b4-84f3-5cad76e6e84e.png)
