### PR TITLE
Use env variables to pass in branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,11 @@ jobs:
         id: build
         shell: bash
         # Pass branch and patch number to Nuke OctoVersion 
-        # (for pull_request events we override the /refs/pull/xx/merge branch to the PR's head branch)
-        run: |
-          ./build.sh \
-            --OctoVersionBranch ${{ github.head_ref || github.ref }} \
-            --OctoVersionPatch ${{ github.run_number }}
+        env:
+          OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }} # For pull_request events we override the /refs/pull/xx/merge branch to the PR's head branch
+          OCTOVERSION_Patch: ${{ github.run_number }}
+        run: ./build.sh --verbosity verbose
+
 
       - name: Tag release (when not pre-release) 🏷️
         if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}


### PR DESCRIPTION
It's recommended we use env variables to pass in the branch name

related to - https://octopusdeploy.slack.com/archives/CDANN5QLT/p1657505612644459